### PR TITLE
Mejoras de rendimiento: OpenMP en métrricas y paralelismo en `distf`

### DIFF
--- a/R/fdist.R
+++ b/R/fdist.R
@@ -11,38 +11,34 @@ distf <- function(A, B = NULL, method, ncores = NULL, p = NULL) {
   } else {
     B <- as.matrix(B)
   }
-  
-  nrowmax <- max(nrow(A), nrow(B))
-  
-  if (is.null(ncores)) {
-    if (nrowmax > 100){
-      numCores <- 1
-      
-    } else {
-      numCores <- 1
-    }
-    
-  }
 
-  cl <- makeCluster(numCores, type = "PSOCK")
-  clusterEvalQ(cl, library(fastDist))
-  clusterExport(cl, varlist = c("B"))
-  
   if (!method %in% fdistregistry$get_entry_names()) {
     stop(paste(method, "not found in fdistregestry"))
   }
-  
+
+  numCores <- if (is.null(ncores)) {
+    max(1L, min(detectCores(logical = FALSE), nrow(A)))
+  } else {
+    max(1L, min(as.integer(ncores), nrow(A)))
+  }
+
+  if (numCores == 1L) {
+    return(fdist(A, B = B, method = method, p = p))
+  }
+
   q <- nrow(A) %/% numCores
   r <- nrow(A) %% numCores
-  
-  my_list1 <- lapply(split(A,                    # Split matrix into list
-                    c(rep(1:numCores, each = q ), 
-                      rep(numCores,   each = r ))
-                    ), matrix, ncol = ncol(A))
-  
-  
-  
-  as.matrix(do.call(rbind.data.frame, parLapply(cl, my_list1, fdist, method = method, B = B)))
+
+  groups <- c(rep(seq_len(numCores), each = q), rep(numCores, each = r))
+  chunks <- lapply(split(A, groups), matrix, ncol = ncol(A))
+
+  cl <- makeCluster(numCores, type = "PSOCK")
+  on.exit(stopCluster(cl), add = TRUE)
+  clusterEvalQ(cl, library(fastDist))
+  clusterExport(cl, varlist = c("B", "method", "p"), envir = environment())
+
+  pieces <- parLapply(cl, chunks, fdist, B = B, method = method, p = p)
+  do.call(rbind, pieces)
 }
 
 fdist <- function(A, B = NULL, method, p = NULL) {

--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -2,6 +2,9 @@
 #include <Rmath.h>
 #include <algorithm>
 #include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 // [[Rcpp::depends(RcppArmadillo)]]
 
@@ -29,7 +32,7 @@ NumericMatrix euclidean(NumericMatrix Ar, NumericMatrix Br) {
   arma::mat C = -2 * (A * B.t());
   C.each_col() += An;
   C.each_row() += Bn.t();
-  C.for_each([](arma::mat::elem_type& val) {val = sqrt(val);});
+  C.for_each([](arma::mat::elem_type& val) {val = std::sqrt(std::max(val, 0.0));});
 
   
   return wrap(C); 
@@ -47,7 +50,8 @@ NumericMatrix manhattan(NumericMatrix Ar, NumericMatrix Br) {
   const bool symmetric = same_input(Ar, Br);
   const double* Ap = A.memptr();
   const double* Bp = B.memptr();
-  
+
+#pragma omp parallel for schedule(static) if(m * n > 10000)
   for (int i = 0; i < m; i++) {
     const int jStart = symmetric ? i : 0;
     for (int j = jStart; j < n; j++) {
@@ -84,13 +88,21 @@ NumericMatrix minkowski(NumericMatrix Ar, NumericMatrix Br, double p) {
   const double* Bp = B.memptr();
 
   double q = 1.0 / p;
-  
+
+#pragma omp parallel for schedule(static) if(m * n > 10000)
   for (int i = 0; i < m; i++) {
     const int jStart = symmetric ? i : 0;
     for (int j = jStart; j < n; j++) {
       double dist = 0.0;
       for (int col = 0; col < k; col++) {
-        dist += std::pow(std::abs(Ap[col * m + i] - Bp[col * n + j]), p);
+        const double delta = std::abs(Ap[col * m + i] - Bp[col * n + j]);
+        if (p == 1.0) {
+          dist += delta;
+        } else if (p == 2.0) {
+          dist += delta * delta;
+        } else {
+          dist += std::pow(delta, p);
+        }
       }
       res(i, j) = dist;
       if (symmetric && i != j) {
@@ -99,7 +111,7 @@ NumericMatrix minkowski(NumericMatrix Ar, NumericMatrix Br, double p) {
     }
   }
   
-  res.for_each([&q](arma::mat::elem_type& val) {val = pow(val, q);});
+  res.for_each([&q](arma::mat::elem_type& val) {val = std::pow(val, q);});
   
   return wrap(res); 
 }
@@ -117,7 +129,8 @@ NumericMatrix canberra(NumericMatrix Ar, NumericMatrix Br) {
   const bool symmetric = same_input(Ar, Br);
   const double* Ap = A.memptr();
   const double* Bp = B.memptr();
-  
+
+#pragma omp parallel for schedule(static) if(m * n > 10000)
   for (int i = 0; i < m; i++) {
     const int jStart = symmetric ? i : 0;
     for (int j = jStart; j < n; j++) {
@@ -152,8 +165,8 @@ NumericMatrix supremum(NumericMatrix Ar, NumericMatrix Br) {
   const bool symmetric = same_input(Ar, Br);
   const double* Ap = A.memptr();
   const double* Bp = B.memptr();
-  
-  
+
+#pragma omp parallel for schedule(static) if(m * n > 10000)
   for (int i = 0; i < m; i++) {
     const int jStart = symmetric ? i : 0;
     for (int j = jStart; j < n; j++) {
@@ -181,7 +194,7 @@ NumericMatrix mahalanobis(NumericMatrix Ar) {
   int m = Ar.nrow(),
       k = Ar.ncol();
   arma::mat A = arma::mat(Ar.begin(), m, k, false); 
-  arma::mat S = arma::inv(arma::cov(A));
+  arma::mat S = arma::inv_sympd(arma::cov(A));
   arma::mat AS = A * S;
   arma::vec q = arma::sum(AS % A, 1);
   arma::mat G = AS * A.t();


### PR DESCRIPTION
### Motivation
- Aumentar el rendimiento de las funciones que calculan distancias para matrices medianas/grandes y mejorar la estabilidad numérica en operaciones críticas.
- Reducir overhead y hacer un uso razonable de cores en la función wrapper R que divide el trabajo (`distf`).

### Description
- Se añade soporte OpenMP e inserta `#pragma omp parallel for` en los bucles principales de `manhattan`, `minkowski`, `canberra` y `supremum` para paralelizar por filas cuando el problema es suficientemente grande (`if(m * n > 10000)`).
- Se optimiza el bucle interno de `minkowski` evitando llamadas genéricas a `std::pow` para los casos frecuentes `p == 1.0` y `p == 2.0`, manteniendo `std::pow` solo para `p` generales.
- Mejora de robustez numérica en `euclidean` haciendo `std::max(val, 0.0)` antes de `sqrt` y en `mahalanobis` usando `arma::inv_sympd(arma::cov(A))` para invertir la matriz de covarianza simétrica definida positiva.
- Refactorización de `distf()` en R para respetar el parámetro `ncores` y calcular un valor por defecto con `detectCores()`, evitar crear un clúster cuando `numCores == 1L`, cerrar el clúster con `on.exit(stopCluster(...))`, exportar variables necesarias al clúster y ensamblar los trozos con `do.call(rbind, ...)`.

### Testing
- Se intentó ejecutar pruebas automáticas en C++/R con `Rcpp::sourceCpp('src/fastDist.cpp')` y comparaciones contra `proxy::dist`, pero la ejecución falló porque `Rscript` no está disponible en este entorno (`command not found: Rscript`).
- Se revisaron los diffs y el código modificado para comprobar los cambios aplicados en `src/fastDist.cpp` y `R/fdist.R`; no se pudieron correr tests unitarios de R debido a la falta de `Rscript` en el entorno de ejecución.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc8b541e4832cb0cd5cba60cd6307)