### PR TITLE
Parallelize Euclidean distance computation with OpenMP

### DIFF
--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -20,22 +20,37 @@ inline bool same_input(const NumericMatrix& Ar, const NumericMatrix& Br) {
 // distancia euclidea
 // [[Rcpp::export(.euclidean)]]
 NumericMatrix euclidean(NumericMatrix Ar, NumericMatrix Br) {
-  int m = Ar.nrow(), 
+  int m = Ar.nrow(),
     n = Br.nrow(),
     k = Ar.ncol();
-  arma::mat A = arma::mat(Ar.begin(), m, k, false); 
-  arma::mat B = arma::mat(Br.begin(), n, k, false); 
-  
-  arma::colvec An =  arma::sum(arma::square(A),1);
-  arma::colvec Bn =  arma::sum(arma::square(B),1);
-  
-  arma::mat C = -2 * (A * B.t());
-  C.each_col() += An;
-  C.each_row() += Bn.t();
-  C.for_each([](arma::mat::elem_type& val) {val = std::sqrt(std::max(val, 0.0));});
-  
-  
-  return wrap(C); 
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+
+  arma::colvec An = arma::sum(arma::square(A), 1);
+  arma::colvec Bn = arma::sum(arma::square(B), 1);
+
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+  for (int i = 0; i < m; i++) {
+    const int jStart = symmetric ? i : 0;
+    for (int j = jStart; j < n; j++) {
+      double dot = 0.0;
+      for (int col = 0; col < k; col++) {
+        dot += Ap[col * m + i] * Bp[col * n + j];
+      }
+      const double sqDist = std::max(An[i] + Bn[j] - 2.0 * dot, 0.0);
+      const double dist = std::sqrt(sqDist);
+      res(i, j) = dist;
+      if (symmetric && i != j) {
+        res(j, i) = dist;
+      }
+    }
+  }
+
+  return wrap(res);
 }
 
 // distancia de manhattan


### PR DESCRIPTION
### Motivation
- Bring the same OpenMP paralellization pattern used for `manhattan` to the Euclidean distance implementation to improve performance on large inputs.
- Preserve the algebraic identity `||a-b||^2 = ||a||^2 + ||b||^2 - 2 a·b` so expensive work remains minimal while enabling per-pair parallelism.

### Description
- Rewrote `.euclidean` in `src/fastDist.cpp` to compute pairwise distances using an explicit `(i,j)` loop instead of the previous vectorized `A * B.t()` + postprocessing approach.
- Added `#pragma omp parallel for schedule(static) if(m * n > 10000)` around the outer loop and used raw memory access via `A.memptr()`/`B.memptr()` for inner-dot computations to mirror the `manhattan` pattern.
- Compute squared distance per pair as `An[i] + Bn[j] - 2.0 * dot` with `std::max(..., 0.0)` before `sqrt` to preserve numerical safety and then store `dist` in `res(i,j)`.
- Added the symmetric fast path (`same_input`) to avoid redundant work and mirror values across the diagonal when `Ar` and `Br` are the same object.

### Testing
- Attempted to run the package test script with `Rscript test.R`, but the command failed because `Rscript` is not available in this environment (`command not found`).
- No automated builds or unit tests were executed in this environment due to the missing `R` runtime, so compilation and runtime validation remain to be run in a proper R toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b552537b00832c8a297b5d2a45dcd0)