### PR TITLE
Parallelize Mahalanobis distance matrix computation

### DIFF
--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -212,8 +212,25 @@ NumericMatrix mahalanobis(NumericMatrix Ar) {
   arma::mat S = arma::inv_sympd(arma::cov(A));
   arma::mat AS = A * S;
   arma::vec q = arma::sum(AS % A, 1);
-  arma::mat G = AS * A.t();
-  arma::mat res = arma::repmat(q, 1, m) + arma::repmat(q.t(), m, 1) - 2.0 * G;
-  res.transform([](double x) { return std::sqrt(std::max(x, 0.0)); });
+  arma::mat res = arma::mat(m, m, arma::fill::zeros);
+  const double* AS_p = AS.memptr();
+  const double* A_p = A.memptr();
+
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+  for (int i = 0; i < m; i++) {
+    for (int j = i; j < m; j++) {
+      double dot = 0.0;
+      for (int col = 0; col < k; col++) {
+        dot += AS_p[col * m + i] * A_p[col * m + j];
+      }
+      const double sqDist = std::max(q[i] + q[j] - 2.0 * dot, 0.0);
+      const double dist = std::sqrt(sqDist);
+      res(i, j) = dist;
+      if (i != j) {
+        res(j, i) = dist;
+      }
+    }
+  }
+
   return wrap(res); 
 }


### PR DESCRIPTION
### Motivation
- The Mahalanobis distance implementation computed a full Gram matrix and used heavy matrix constructions which duplicate work and are not parallelized.
- The goal is to reduce memory and compute overhead and enable multi-threaded computation for large inputs by exploiting symmetry and explicit pairwise dot-products.

### Description
- Replaced the `AS * A.t()` + `repmat` approach with an explicit upper-triangular loop that computes pairwise dot-products and writes mirrored entries to keep the result symmetric.
- Added an OpenMP parallel loop `#pragma omp parallel for schedule(static) if(m * m > 10000)` to parallelize the pairwise computation, matching heuristics used elsewhere in the file.
- Used raw pointers from `memptr()` for `AS` and `A` to avoid repeated indexing overhead and kept the numeric safeguard `std::max(..., 0.0)` before `std::sqrt` to avoid negative round-off artifacts.

### Testing
- Attempted an R-based runtime check with `Rscript` to compile and validate symmetry and diagonal zeros, but the test could not run because `Rscript` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b555cac4dc832c9ead169d78c53c51)