### PR TITLE
docs: añadir documentación roxygen para distf y fdist

### DIFF
--- a/R/fdist.R
+++ b/R/fdist.R
@@ -1,7 +1,22 @@
 
-
-
-
+#' Distancias por bloques en paralelo
+#'
+#' Calcula una matriz de distancias entre las filas de `A` y `B` repartiendo
+#' las filas de `A` por bloques y ejecutando cada bloque en paralelo con
+#' `parallel::parLapply()`. Internamente delega el cálculo en [fdist()].
+#'
+#' @param A Matriz o estructura coercible a matriz con las observaciones de
+#'   origen (filas).
+#' @param B Matriz o estructura coercible a matriz con las observaciones de
+#'   destino (filas). Si es `NULL`, se usa `A`.
+#' @param method Nombre del método de distancia registrado en `fdistregistry`.
+#' @param ncores Número de núcleos para paralelizar. Si es `NULL`, se usa el
+#'   valor configurado internamente por la función.
+#' @param p Parámetro adicional para métodos que lo requieren (por ejemplo,
+#'   Minkowski).
+#'
+#' @return Una matriz numérica con las distancias calculadas entre `A` y `B`.
+#' @export
 distf <- function(A, B = NULL, method, ncores = NULL, p = NULL) {
   library(parallel)
 
@@ -45,6 +60,22 @@ distf <- function(A, B = NULL, method, ncores = NULL, p = NULL) {
   as.matrix(do.call(rbind.data.frame, parLapply(cl, my_list1, fdist, method = method, B = B)))
 }
 
+#' Distancias rápidas entre observaciones
+#'
+#' Calcula distancias entre filas de `A` y `B` usando una implementación
+#' registrada en `fdistregistry`. Si `method = "mahalanobis"`, el cálculo se
+#' realiza con la firma específica de ese método.
+#'
+#' @param A Matriz o estructura coercible a matriz con las observaciones de
+#'   origen (filas).
+#' @param B Matriz o estructura coercible a matriz con las observaciones de
+#'   destino (filas). Si es `NULL`, se usa `A`.
+#' @param method Nombre del método de distancia registrado en `fdistregistry`.
+#' @param p Parámetro adicional para métodos que lo requieren (por ejemplo,
+#'   Minkowski).
+#'
+#' @return Una matriz numérica con las distancias calculadas.
+#' @export
 fdist <- function(A, B = NULL, method, p = NULL) {
   if (!method %in% fdistregistry$get_entry_names()) {
     stop(paste(method, "not found in fdistregestry"))


### PR DESCRIPTION
### Motivation
- Añadir documentación roxygen a las funciones exportadas para mejorar la ayuda generada y la mantenibilidad del paquete.

### Description
- Se añadieron bloques de documentación roxygen para `distf` y `fdist` en `R/fdist.R`, incluyendo descripciones, parámetros (`A`, `B`, `method`, `ncores`, `p`), valor de retorno y la etiqueta `@export`.

### Testing
- Se intentó validar el archivo con `Rscript -e "parse(file='R/fdist.R')"` pero falló porque `Rscript` no está disponible en el entorno (`bash: command not found: Rscript`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b67f45a7a0832c977a349f126f166c)