### PR TITLE
Optimize Euclidean and Mahalanobis distance kernels

### DIFF
--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -27,25 +27,28 @@ NumericMatrix euclidean(NumericMatrix Ar, NumericMatrix Br) {
   arma::mat B = arma::mat(Br.begin(), n, k, false);
   arma::mat res = arma::mat(m, n, arma::fill::zeros);
   const bool symmetric = same_input(Ar, Br);
-  const double* Ap = A.memptr();
-  const double* Bp = B.memptr();
+  const arma::colvec An = arma::sum(arma::square(A), 1);
+  const arma::colvec Bn = symmetric ? An : arma::sum(arma::square(B), 1);
+  const arma::mat G = A * B.t();
 
-  arma::colvec An = arma::sum(arma::square(A), 1);
-  arma::colvec Bn = arma::sum(arma::square(B), 1);
-
-#pragma omp parallel for schedule(static) if(m * n > 10000)
-  for (int i = 0; i < m; i++) {
-    const int jStart = symmetric ? i : 0;
-    for (int j = jStart; j < n; j++) {
-      double dot = 0.0;
-      for (int col = 0; col < k; col++) {
-        dot += Ap[col * m + i] * Bp[col * n + j];
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        const double sqDist = std::max(An[i] + An[j] - 2.0 * G(i, j), 0.0);
+        const double dist = std::sqrt(sqDist);
+        res(i, j) = dist;
+        if (i != j) {
+          res(j, i) = dist;
+        }
       }
-      const double sqDist = std::max(An[i] + Bn[j] - 2.0 * dot, 0.0);
-      const double dist = std::sqrt(sqDist);
-      res(i, j) = dist;
-      if (symmetric && i != j) {
-        res(j, i) = dist;
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        const double sqDist = std::max(An[i] + Bn[j] - 2.0 * G(i, j), 0.0);
+        res(i, j) = std::sqrt(sqDist);
       }
     }
   }
@@ -212,18 +215,13 @@ NumericMatrix mahalanobis(NumericMatrix Ar) {
   arma::mat S = arma::inv_sympd(arma::cov(A));
   arma::mat AS = A * S;
   arma::vec q = arma::sum(AS % A, 1);
+  arma::mat G = AS * A.t();
   arma::mat res = arma::mat(m, m, arma::fill::zeros);
-  const double* AS_p = AS.memptr();
-  const double* A_p = A.memptr();
 
 #pragma omp parallel for schedule(static) if(m * m > 10000)
   for (int i = 0; i < m; i++) {
     for (int j = i; j < m; j++) {
-      double dot = 0.0;
-      for (int col = 0; col < k; col++) {
-        dot += AS_p[col * m + i] * A_p[col * m + j];
-      }
-      const double sqDist = std::max(q[i] + q[j] - 2.0 * dot, 0.0);
+      const double sqDist = std::max(q[i] + q[j] - 2.0 * G(i, j), 0.0);
       const double dist = std::sqrt(sqDist);
       res(i, j) = dist;
       if (i != j) {


### PR DESCRIPTION
### Motivation
- Reduce the hot-path cost of pairwise distance calculations by shifting per-pair dot-product work into BLAS-backed matrix multiplies and precomputed norms to improve throughput for medium/large inputs.

### Description
- Rewrote the `.euclidean` kernel in `src/fastDist.cpp` to precompute squared norms (`An`, `Bn`) and the Gram matrix `G = A * B.t()` and replaced the inner per-pair dot-product loop with lookups into `G`, preserving a symmetric half-matrix fast path.
- Rewrote the `.mahalanobis` kernel to precompute `G = AS * A.t()` and use it in the pairwise loop instead of computing dot-products per pair.
- Kept existing OpenMP pragmas and preserved numerical safeguards (Clamping negative squared distances to zero and taking `sqrt`).

### Testing
- Attempted to build the package with `R CMD INSTALL .`, which failed because `R` is not installed in the current environment (`bash: command not found: R`).
- Performed a static review of the `src/fastDist.cpp` diff and inspected the modified kernels to confirm the new logic and that the symmetric/non-symmetric paths are handled correctly; no runtime benchmarks or automated unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6823115b4832c897dbfa44fcac561)