### PR TITLE
Add parallelDist microbenchmark suite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,3 +9,6 @@ Description: More about what it does (maybe more than one line)
 License: What license is it under?
 Imports: Rcpp (>= 1.0.0)
 LinkingTo: Rcpp, RcppArmadillo, registry, parallel
+Suggests: testthat,
+    microbenchmark,
+    parallelDist

--- a/R/benchmark_parallelDist.R
+++ b/R/benchmark_parallelDist.R
@@ -1,0 +1,248 @@
+.validate_distance_method <- function(method) {
+  valid_methods <- c("euclidean", "manhattan", "minkowski")
+  if (!method %in% valid_methods) {
+    stop(sprintf(
+      "method must be one of %s",
+      paste(shQuote(valid_methods), collapse = ", ")
+    ))
+  }
+}
+
+.require_benchmark_packages <- function() {
+  missing_packages <- c()
+
+  if (!requireNamespace("parallelDist", quietly = TRUE)) {
+    missing_packages <- c(missing_packages, "parallelDist")
+  }
+
+  if (!requireNamespace("microbenchmark", quietly = TRUE)) {
+    missing_packages <- c(missing_packages, "microbenchmark")
+  }
+
+  if (length(missing_packages) > 0) {
+    stop(
+      sprintf(
+        "Missing required package(s): %s",
+        paste(missing_packages, collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+crossdist_parallelDist <- function(A,
+                                   B,
+                                   method = "euclidean",
+                                   p = NULL,
+                                   threads = NULL,
+                                   block_size = NULL) {
+  if (!requireNamespace("parallelDist", quietly = TRUE)) {
+    stop("Package 'parallelDist' is required for crossdist_parallelDist().", call. = FALSE)
+  }
+
+  .validate_distance_method(method)
+
+  A <- as.matrix(A)
+  B <- as.matrix(B)
+
+  if (ncol(A) != ncol(B)) {
+    stop("A and B must have the same number of columns.", call. = FALSE)
+  }
+
+  if (is.null(block_size)) {
+    block_size <- max(nrow(A), 1L)
+  }
+
+  block_size <- as.integer(block_size)
+  if (is.na(block_size) || block_size < 1L) {
+    stop("block_size must be a positive integer.", call. = FALSE)
+  }
+
+  n_a <- nrow(A)
+  n_b <- nrow(B)
+  result <- matrix(NA_real_, nrow = n_a, ncol = n_b)
+
+  for (start in seq.int(1L, n_b, by = block_size)) {
+    end <- min(start + block_size - 1L, n_b)
+    index <- start:end
+    combined <- rbind(A, B[index, , drop = FALSE])
+
+    call_args <- list(
+      x = combined,
+      method = method,
+      threads = threads
+    )
+
+    if (identical(method, "minkowski")) {
+      if (is.null(p)) {
+        stop("Parameter 'p' is required when method = 'minkowski'.", call. = FALSE)
+      }
+      call_args$p <- p
+    }
+
+    block_dist <- do.call(parallelDist::parDist, call_args)
+    block_matrix <- as.matrix(block_dist)
+    result[, index] <- block_matrix[seq_len(n_a), n_a + seq_along(index), drop = FALSE]
+  }
+
+  result
+}
+
+benchmark_parallelDist <- function(A = NULL,
+                                   B = NULL,
+                                   a_nrow = 1000L,
+                                   n_features = 1000L,
+                                   b_sizes = c(1000L, 5000L, 10000L, 20000L),
+                                   methods = c("euclidean", "manhattan", "minkowski"),
+                                   minkowski_p = 3,
+                                   times = 1L,
+                                   seed = 123,
+                                   unit = "s",
+                                   threads = NULL,
+                                   block_size = NULL,
+                                   check = TRUE) {
+  .require_benchmark_packages()
+
+  methods <- unique(methods)
+  invalid_methods <- setdiff(methods, c("euclidean", "manhattan", "minkowski"))
+  if (length(invalid_methods) > 0) {
+    stop(
+      sprintf(
+        "Unsupported method(s): %s",
+        paste(shQuote(invalid_methods), collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
+
+  b_sizes <- sort(unique(as.integer(b_sizes)))
+  if (any(is.na(b_sizes)) || any(b_sizes < 1L)) {
+    stop("b_sizes must contain positive integers.", call. = FALSE)
+  }
+
+  a_nrow <- as.integer(a_nrow)
+  n_features <- as.integer(n_features)
+  times <- as.integer(times)
+
+  if (is.null(A)) {
+    set.seed(seed)
+    A <- matrix(runif(a_nrow * n_features), nrow = a_nrow, ncol = n_features)
+  } else {
+    A <- as.matrix(A)
+    a_nrow <- nrow(A)
+    n_features <- ncol(A)
+  }
+
+  max_b <- max(b_sizes)
+  if (is.null(B)) {
+    set.seed(seed + 1L)
+    B <- matrix(runif(max_b * n_features), nrow = max_b, ncol = n_features)
+  } else {
+    B <- as.matrix(B)
+    if (ncol(B) != n_features) {
+      stop("B must have the same number of columns as A.", call. = FALSE)
+    }
+    if (nrow(B) < max_b) {
+      stop("B must have at least max(b_sizes) rows.", call. = FALSE)
+    }
+  }
+
+  if (is.null(block_size)) {
+    block_size <- max(nrow(A), 1L)
+  }
+
+  benchmark_rows <- list()
+  benchmark_objects <- list()
+  benchmark_id <- 1L
+
+  for (method in methods) {
+    for (b_size in b_sizes) {
+      current_B <- B[seq_len(b_size), , drop = FALSE]
+
+      fastdist_call <- function() {
+        if (identical(method, "minkowski")) {
+          fdist(A, current_B, method = method, p = minkowski_p)
+        } else {
+          fdist(A, current_B, method = method)
+        }
+      }
+
+      paralleldist_call <- function() {
+        if (identical(method, "minkowski")) {
+          crossdist_parallelDist(
+            A,
+            current_B,
+            method = method,
+            p = minkowski_p,
+            threads = threads,
+            block_size = block_size
+          )
+        } else {
+          crossdist_parallelDist(
+            A,
+            current_B,
+            method = method,
+            threads = threads,
+            block_size = block_size
+          )
+        }
+      }
+
+      if (isTRUE(check)) {
+        fastdist_result <- fastdist_call()
+        paralleldist_result <- paralleldist_call()
+
+        if (!isTRUE(all.equal(fastdist_result, paralleldist_result, tolerance = 1e-8))) {
+          stop(
+            sprintf(
+              "The results differ for method '%s' and b_size = %s.",
+              method,
+              b_size
+            ),
+            call. = FALSE
+          )
+        }
+      }
+
+      benchmark <- microbenchmark::microbenchmark(
+        fastDist = fastdist_call(),
+        parallelDist = paralleldist_call(),
+        times = times,
+        unit = unit,
+        check = NULL
+      )
+
+      benchmark_summary <- summary(benchmark)
+      benchmark_summary$method <- method
+      benchmark_summary$b_rows <- b_size
+      benchmark_summary$a_rows <- nrow(A)
+      benchmark_summary$n_features <- ncol(A)
+      benchmark_summary$minkowski_p <- if (identical(method, "minkowski")) minkowski_p else NA_real_
+      benchmark_rows[[benchmark_id]] <- benchmark_summary
+      benchmark_objects[[paste(method, b_size, sep = "__")]] <- benchmark
+      benchmark_id <- benchmark_id + 1L
+    }
+  }
+
+  summary_table <- do.call(rbind, benchmark_rows)
+  rownames(summary_table) <- NULL
+
+  list(
+    parameters = list(
+      a_rows = nrow(A),
+      n_features = ncol(A),
+      b_sizes = b_sizes,
+      methods = methods,
+      minkowski_p = minkowski_p,
+      times = times,
+      unit = unit,
+      threads = threads,
+      block_size = block_size,
+      check = check
+    ),
+    summary = summary_table,
+    benchmarks = benchmark_objects,
+    A = A,
+    B = B[seq_len(max_b), , drop = FALSE]
+  )
+}

--- a/README.md
+++ b/README.md
@@ -20,3 +20,30 @@ Tiempo (segundos) de cálculo de distancias entre filas de una matriz de dimensi
 |       | proxy_supremum       | 395.2    | 401.1    | 413.0    | 408.1    | 419.7    | 483.7    | 30    |
 |       | fastDist_mahalanobis | 2040.2   | 2078.8   | 2108.2   | 2100.7   | 2128.0   | 2244.6   | 30    |
 |       | proxy_mahalanobis    | 107772.6 | 109274.8 | 111446.1 | 110321.4 | 112152.8 | 122567.6 | 30    |
+
+## benchmark fastDist vs parallelDist
+
+Se agregó un benchmark reproducible para comparar `fastDist` contra `parallelDist`
+en el cálculo de distancias entre las filas de `A` y `B` para los métodos:
+
+- Euclidean
+- Manhattan
+- Minkowski
+
+El script está en `inst/benchmarks/parallelDist_microbenchmark.R` y ejecuta el caso:
+
+- `A`: `1000 x 1000`
+- `B`: `1000`, `5000`, `10000` y `20000` filas
+
+Uso sugerido:
+
+```r
+install.packages(c("microbenchmark", "parallelDist"))
+devtools::load_all(".")
+source("inst/benchmarks/parallelDist_microbenchmark.R")
+```
+
+Internamente, la comparación con `parallelDist` se resuelve por bloques sobre las filas
+de `B`, porque `parallelDist::parDist()` calcula matrices de distancia cuadradas. De esta
+forma se puede extraer la submatriz cruzada `A x B` y estudiar cómo escala el tiempo a
+medida que crece `B`.

--- a/inst/benchmarks/parallelDist_microbenchmark.R
+++ b/inst/benchmarks/parallelDist_microbenchmark.R
@@ -1,0 +1,20 @@
+# Microbenchmark: fastDist vs parallelDist for A (1000 x 1000) against B (n x 1000)
+#
+# Example:
+# install.packages(c("microbenchmark", "parallelDist"))
+# devtools::load_all(".")
+# source("inst/benchmarks/parallelDist_microbenchmark.R")
+
+benchmark_result <- benchmark_parallelDist(
+  a_nrow = 1000L,
+  n_features = 1000L,
+  b_sizes = c(1000L, 5000L, 10000L, 20000L),
+  methods = c("euclidean", "manhattan", "minkowski"),
+  minkowski_p = 3,
+  times = 1L,
+  unit = "s",
+  block_size = 1000L,
+  check = FALSE
+)
+
+print(benchmark_result$summary)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(fastDist)
+
+test_check("fastDist")

--- a/tests/testthat/test-benchmark_parallelDist.R
+++ b/tests/testthat/test-benchmark_parallelDist.R
@@ -1,0 +1,58 @@
+test_that("crossdist_parallelDist matches fastDist on small matrices", {
+  skip_if_not_installed("parallelDist")
+
+  set.seed(42)
+  A <- matrix(runif(12), nrow = 4)
+  B <- matrix(runif(21), nrow = 7)
+
+  expect_equal(
+    crossdist_parallelDist(A, B, method = "euclidean", block_size = 3L),
+    fdist(A, B, method = "euclidean"),
+    tolerance = 1e-8
+  )
+
+  expect_equal(
+    crossdist_parallelDist(A, B, method = "manhattan", block_size = 3L),
+    fdist(A, B, method = "manhattan"),
+    tolerance = 1e-8
+  )
+
+  expect_equal(
+    crossdist_parallelDist(A, B, method = "minkowski", p = 3, block_size = 3L),
+    fdist(A, B, method = "minkowski", p = 3),
+    tolerance = 1e-8
+  )
+})
+
+test_that("benchmark_parallelDist returns a summary for each method and B size", {
+  skip_if_not_installed("parallelDist")
+  skip_if_not_installed("microbenchmark")
+
+  set.seed(99)
+  A <- matrix(runif(24), nrow = 6)
+  B <- matrix(runif(80), nrow = 20)
+
+  benchmark_result <- benchmark_parallelDist(
+    A = A,
+    B = B,
+    b_sizes = c(5L, 10L),
+    methods = c("euclidean", "minkowski"),
+    minkowski_p = 3,
+    times = 1L,
+    unit = "ms",
+    block_size = 5L,
+    check = TRUE
+  )
+
+  expect_true(is.list(benchmark_result))
+  expect_named(
+    benchmark_result,
+    c("parameters", "summary", "benchmarks", "A", "B")
+  )
+  expect_equal(
+    sort(unique(benchmark_result$summary$expr)),
+    c("fastDist", "parallelDist")
+  )
+  expect_equal(length(unique(benchmark_result$summary$method)), 2L)
+  expect_equal(length(unique(benchmark_result$summary$b_rows)), 2L)
+})


### PR DESCRIPTION
### Motivation

- Proveer un microbenchmark reproducible que compare `fastDist` contra `parallelDist` para las distancias Euclidean, Manhattan y Minkowski y estudiar cómo escala el tiempo cuando la matriz `B` crece hasta 20000 filas.
- Evitar la limitación de `parallelDist::parDist()` (devuelve matrices cuadradas) resolviendo la comparación `A x B` por bloques sobre las filas de `B`.

### Description

- Añadido `R/benchmark_parallelDist.R` con `crossdist_parallelDist()` (implementa el enfoque por bloques usando `parallelDist::parDist`) y `benchmark_parallelDist()` (gestiona generación de datos, ejecución con `microbenchmark` y resumen de resultados).
- Añadido el script reproducible `inst/benchmarks/parallelDist_microbenchmark.R` para ejecutar el caso solicitado `A = 1000 x 1000` y `B` con `1000, 5000, 10000, 20000` filas.
- Añadidos tests `tests/testthat/test-benchmark_parallelDist.R` que verifican la equivalencia de `crossdist_parallelDist()` y `fdist()` en matrices pequeñas y la estructura del resultado del benchmark, y creado `tests/testthat.R` para `testthat` integration.
- Documentado el flujo en `README.md` y agregado `testthat`, `microbenchmark` y `parallelDist` a `Suggests` en `DESCRIPTION`.

### Testing

- `git diff --check` fue ejecutado y no reportó problemas.
- No se pudieron ejecutar las pruebas R automatizadas ni `R CMD check` porque el entorno donde se generó el PR no tiene `R`/`Rscript` instalado, por lo que los tests en `tests/testthat/` y el microbenchmark no se ejecutaron aquí.
- Las pruebas unitarias basadas en `testthat` y el benchmark con `microbenchmark` están incluidas y pueden ejecutarse localmente con `Rscript`/`R CMD check` una vez que `R` y las dependencias (`microbenchmark`, `parallelDist`) estén disponibles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bebd989a18832ca0941f04f82af148)