### PR TITLE
Add correlation distance metric with Rcpp/OpenMP implementation and tests

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,10 @@
     .Call(`_fastDist_minkowski`, Ar, Br, p)
 }
 
+.correlation <- function(Ar, Br) {
+    .Call(`_fastDist_correlation`, Ar, Br)
+}
+
 .canberra <- function(Ar, Br) {
     .Call(`_fastDist_canberra`, Ar, Br)
 }

--- a/R/registry.R
+++ b/R/registry.R
@@ -25,6 +25,10 @@ fdistregistry$set_entry(method = "minkowski",
                         p      = 2,
                         description = "distancia de Minkowski")
 
+fdistregistry$set_entry(method = "correlation",  
+                        fun    = .correlation,
+                        description = "distancia de correlacion")
+
 fdistregistry$set_entry(method = "canberra",  
                         fun    = .canberra,
                         description = "distancia de canberra")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -48,6 +48,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// correlation
+NumericMatrix correlation(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_correlation(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(correlation(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
 // canberra
 NumericMatrix canberra(NumericMatrix Ar, NumericMatrix Br);
 RcppExport SEXP _fastDist_canberra(SEXP ArSEXP, SEXP BrSEXP) {
@@ -88,6 +100,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_fastDist_euclidean", (DL_FUNC) &_fastDist_euclidean, 2},
     {"_fastDist_manhattan", (DL_FUNC) &_fastDist_manhattan, 2},
     {"_fastDist_minkowski", (DL_FUNC) &_fastDist_minkowski, 3},
+    {"_fastDist_correlation", (DL_FUNC) &_fastDist_correlation, 2},
     {"_fastDist_canberra", (DL_FUNC) &_fastDist_canberra, 2},
     {"_fastDist_supremum", (DL_FUNC) &_fastDist_supremum, 2},
     {"_fastDist_mahalanobis", (DL_FUNC) &_fastDist_mahalanobis, 1},

--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -149,6 +149,73 @@ NumericMatrix minkowski(NumericMatrix Ar, NumericMatrix Br, double p) {
 }
 
 
+// distancia de correlacion
+// [[Rcpp::export(.correlation)]]
+NumericMatrix correlation(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+  arma::colvec meanA = arma::mean(A, 1);
+  arma::colvec meanB = arma::mean(B, 1);
+  arma::colvec normA(m, arma::fill::zeros);
+  arma::colvec normB(n, arma::fill::zeros);
+
+#pragma omp parallel for schedule(static) if(m > 100)
+  for (int i = 0; i < m; i++) {
+    double ss = 0.0;
+    for (int col = 0; col < k; col++) {
+      const double centered = Ap[col * m + i] - meanA[i];
+      ss += centered * centered;
+    }
+    normA[i] = std::sqrt(ss);
+  }
+
+#pragma omp parallel for schedule(static) if(n > 100)
+  for (int j = 0; j < n; j++) {
+    double ss = 0.0;
+    for (int col = 0; col < k; col++) {
+      const double centered = Bp[col * n + j] - meanB[j];
+      ss += centered * centered;
+    }
+    normB[j] = std::sqrt(ss);
+  }
+
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+  for (int i = 0; i < m; i++) {
+    const int jStart = symmetric ? i : 0;
+    for (int j = jStart; j < n; j++) {
+      double corr = 0.0;
+      const double denom = normA[i] * normB[j];
+
+      if (denom > 0.0) {
+        double dot = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double a = Ap[col * m + i] - meanA[i];
+          const double b = Bp[col * n + j] - meanB[j];
+          dot += a * b;
+        }
+        corr = dot / denom;
+        corr = std::max(-1.0, std::min(1.0, corr));
+      }
+
+      const double dist = 1.0 - corr;
+      res(i, j) = dist;
+      if (symmetric && i != j) {
+        res(j, i) = dist;
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
 // distancia de canberra
 // [[Rcpp::export(.canberra)]]
 NumericMatrix canberra(NumericMatrix Ar, NumericMatrix Br) {

--- a/tests/testthat/test-correlation.R
+++ b/tests/testthat/test-correlation.R
@@ -1,0 +1,32 @@
+test_that("fdist correlation matches base cor-derived distance", {
+  A <- matrix(c(
+    1, 2, 3,
+    2, 5, 6,
+    3, 1, 0
+  ), nrow = 3, byrow = TRUE)
+  B <- matrix(c(
+    2, 1, 4,
+    4, 4, 1
+  ), nrow = 2, byrow = TRUE)
+
+  expected <- 1 - cor(t(A), t(B))
+
+  expect_equal(
+    fdist(A, B, method = "correlation"),
+    expected,
+    tolerance = 1e-8
+  )
+})
+
+test_that("fdist correlation returns a symmetric zero-diagonal matrix for identical input", {
+  A <- matrix(c(
+    1, 2, 3,
+    2, 5, 6,
+    3, 1, 0
+  ), nrow = 3, byrow = TRUE)
+
+  result <- fdist(A, method = "correlation")
+
+  expect_equal(result, t(result), tolerance = 1e-8)
+  expect_equal(diag(result), rep(0, nrow(A)), tolerance = 1e-8)
+})


### PR DESCRIPTION
### Motivation
- Provide a correlation-based distance (1 - Pearson correlation) for the fastDist package so users can compute correlation distances efficiently and in parallel.

### Description
- Implemented `correlation` in `src/fastDist.cpp` computing `1 - corr` with centered vectors, numeric stability clamping, symmetric optimization, and OpenMP-parallelized loops.
- Added the Rcpp export entry for `_fastDist_correlation` in `src/RcppExports.cpp` and a thin R wrapper `.correlation` in `R/RcppExports.R`.
- Registered the new method in `R/registry.R` as `method = "correlation"` so `fdist(..., method = "correlation")` dispatches correctly.
- Added unit tests in `tests/testthat/test-correlation.R` that compare the new implementation to `1 - cor()` and verify symmetry and zero diagonal for identical inputs.

### Testing
- Ran the package test suite with `devtools::test()`, executing `tests/testthat/test-correlation.R`, and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfbfc41cdc832cba8711a5f3c115f3)