### PR TITLE
Add cosine distance metric (C++/R) and unit tests

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,6 +17,10 @@
     .Call(`_fastDist_correlation`, Ar, Br)
 }
 
+.cosine <- function(Ar, Br) {
+    .Call(`_fastDist_cosine`, Ar, Br)
+}
+
 .canberra <- function(Ar, Br) {
     .Call(`_fastDist_canberra`, Ar, Br)
 }
@@ -28,4 +32,3 @@
 .mahalanobis <- function(Ar) {
     .Call(`_fastDist_mahalanobis`, Ar)
 }
-

--- a/R/registry.R
+++ b/R/registry.R
@@ -29,6 +29,10 @@ fdistregistry$set_entry(method = "correlation",
                         fun    = .correlation,
                         description = "distancia de correlacion")
 
+fdistregistry$set_entry(method = "cosine",  
+                        fun    = .cosine,
+                        description = "distancia del coseno")
+
 fdistregistry$set_entry(method = "canberra",  
                         fun    = .canberra,
                         description = "distancia de canberra")
@@ -41,7 +45,6 @@ fdistregistry$set_entry(method = "supremum",
 fdistregistry$set_entry(method = "mahalanobis",  
                         fun    = .mahalanobis,
                         description = "distancia de Mahalanobis")
-
 
 
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -60,6 +60,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cosine
+NumericMatrix cosine(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_cosine(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(cosine(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
 // canberra
 NumericMatrix canberra(NumericMatrix Ar, NumericMatrix Br);
 RcppExport SEXP _fastDist_canberra(SEXP ArSEXP, SEXP BrSEXP) {
@@ -101,6 +113,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_fastDist_manhattan", (DL_FUNC) &_fastDist_manhattan, 2},
     {"_fastDist_minkowski", (DL_FUNC) &_fastDist_minkowski, 3},
     {"_fastDist_correlation", (DL_FUNC) &_fastDist_correlation, 2},
+    {"_fastDist_cosine", (DL_FUNC) &_fastDist_cosine, 2},
     {"_fastDist_canberra", (DL_FUNC) &_fastDist_canberra, 2},
     {"_fastDist_supremum", (DL_FUNC) &_fastDist_supremum, 2},
     {"_fastDist_mahalanobis", (DL_FUNC) &_fastDist_mahalanobis, 1},

--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -267,6 +267,62 @@ NumericMatrix correlation(NumericMatrix Ar, NumericMatrix Br) {
   return wrap(res);
 }
 
+// distancia del coseno
+// [[Rcpp::export(.cosine)]]
+NumericMatrix cosine(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+  arma::colvec normA = arma::sqrt(arma::sum(arma::square(A), 1));
+  arma::colvec normB = arma::sqrt(arma::sum(arma::square(B), 1));
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        double cos_sim = 0.0;
+        const double denom = normA[i] * normB[j];
+        if (denom > 0.0) {
+          double dot = 0.0;
+          for (int col = 0; col < k; col++) {
+            dot += Ap[col * m + i] * Bp[col * n + j];
+          }
+          cos_sim = dot / denom;
+          cos_sim = std::max(-1.0, std::min(1.0, cos_sim));
+        }
+        const double dist = 1.0 - cos_sim;
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        double cos_sim = 0.0;
+        const double denom = normA[i] * normB[j];
+        if (denom > 0.0) {
+          double dot = 0.0;
+          for (int col = 0; col < k; col++) {
+            dot += Ap[col * m + i] * Bp[col * n + j];
+          }
+          cos_sim = dot / denom;
+          cos_sim = std::max(-1.0, std::min(1.0, cos_sim));
+        }
+        res(i, j) = 1.0 - cos_sim;
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
 
 // distancia de canberra
 // [[Rcpp::export(.canberra)]]

--- a/tests/testthat/test-cosine.R
+++ b/tests/testthat/test-cosine.R
@@ -1,0 +1,39 @@
+test_that("fdist cosine matches manual cosine distance", {
+  A <- matrix(c(
+    1, 0, 0,
+    1, 1, 0,
+    0, 1, 1
+  ), nrow = 3, byrow = TRUE)
+  B <- matrix(c(
+    1, 0, 1,
+    0, 1, 0
+  ), nrow = 2, byrow = TRUE)
+
+  expected <- matrix(0, nrow(A), nrow(B))
+  for (i in seq_len(nrow(A))) {
+    for (j in seq_len(nrow(B))) {
+      denom <- sqrt(sum(A[i, ]^2)) * sqrt(sum(B[j, ]^2))
+      cos_sim <- if (denom > 0) sum(A[i, ] * B[j, ]) / denom else 0
+      expected[i, j] <- 1 - cos_sim
+    }
+  }
+
+  expect_equal(
+    fdist(A, B, method = "cosine"),
+    expected,
+    tolerance = 1e-8
+  )
+})
+
+test_that("fdist cosine returns a symmetric zero-diagonal matrix for identical input", {
+  A <- matrix(c(
+    1, 2, 3,
+    2, 5, 6,
+    3, 1, 0
+  ), nrow = 3, byrow = TRUE)
+
+  result <- fdist(A, method = "cosine")
+
+  expect_equal(result, t(result), tolerance = 1e-8)
+  expect_equal(diag(result), rep(0, nrow(A)), tolerance = 1e-8)
+})


### PR DESCRIPTION
### Motivation

- Add a cosine-distance metric to the package to provide an angular similarity based distance in addition to existing metrics.

### Description

- Implemented the `cosine` function in `src/fastDist.cpp` that computes `1 - cosine_similarity` with Armadillo buffers, symmetric input optimization, OpenMP-parallel loops, denom zero-handling, and clamping of similarity to [-1,1].
- Exposed the new symbol via `src/RcppExports.cpp` and added the R wrapper `.cosine` in `R/RcppExports.R` to call the native routine. 
- Registered the new method in `R/registry.R` with `method = "cosine"` and `description = "distancia del coseno"`.
- Added unit tests in `tests/testthat/test-cosine.R` that validate the metric against a manual computation and check symmetry and zero-diagonal behavior for identical inputs.

### Testing

- Compiled the package and built the native code successfully via the normal package build process. 
- Ran the package unit tests with `devtools::test()` (the `testthat` suite), including `tests/testthat/test-cosine.R`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e487c046a8832cbdf0c520792a919e)