### PR TITLE
Ampliar benchmark de fastDist vs parallelDist a más métricas implementadas

### DIFF
--- a/R/benchmark_parallelDist.R
+++ b/R/benchmark_parallelDist.R
@@ -1,5 +1,23 @@
+.parallelDist_method_map <- function() {
+  c(
+    euclidean = "euclidean",
+    manhattan = "manhattan",
+    minkowski = "minkowski",
+    correlation = "correlation",
+    cosine = "cosine",
+    canberra = "canberra",
+    supremum = "maximum"
+  )
+}
+
+.supported_parallelDist_methods <- function() {
+  map <- .parallelDist_method_map()
+  implemented <- fdistregistry$get_entry_names()
+  intersect(names(map), implemented)
+}
+
 .validate_distance_method <- function(method) {
-  valid_methods <- c("euclidean", "manhattan", "minkowski")
+  valid_methods <- .supported_parallelDist_methods()
   if (!method %in% valid_methods) {
     stop(sprintf(
       "method must be one of %s",
@@ -41,6 +59,8 @@ crossdist_parallelDist <- function(A,
   }
 
   .validate_distance_method(method)
+  method_map <- .parallelDist_method_map()
+  parallel_method <- unname(method_map[[method]])
 
   A <- as.matrix(A)
   B <- as.matrix(B)
@@ -69,7 +89,7 @@ crossdist_parallelDist <- function(A,
 
     call_args <- list(
       x = combined,
-      method = method,
+      method = parallel_method,
       threads = threads
     )
 
@@ -93,7 +113,7 @@ benchmark_parallelDist <- function(A = NULL,
                                    a_nrow = 1000L,
                                    n_features = 1000L,
                                    b_sizes = c(1000L, 5000L, 10000L, 20000L),
-                                   methods = c("euclidean", "manhattan", "minkowski"),
+                                   methods = .supported_parallelDist_methods(),
                                    minkowski_p = 3,
                                    times = 1L,
                                    seed = 123,
@@ -104,7 +124,7 @@ benchmark_parallelDist <- function(A = NULL,
   .require_benchmark_packages()
 
   methods <- unique(methods)
-  invalid_methods <- setdiff(methods, c("euclidean", "manhattan", "minkowski"))
+  invalid_methods <- setdiff(methods, .supported_parallelDist_methods())
   if (length(invalid_methods) > 0) {
     stop(
       sprintf(

--- a/inst/benchmarks/parallelDist_microbenchmark.R
+++ b/inst/benchmarks/parallelDist_microbenchmark.R
@@ -10,7 +10,6 @@ benchmark_result <- benchmark_parallelDist(
   n_features = 1000L,
   # b_sizes = c(1000L, 5000L, 10000L, 20000L),
   b_sizes = c(1000L, 5000L, 10000L, 20000L),
-  methods = c("euclidean", "manhattan", "minkowski"),
   minkowski_p = 3,
   times = 1L,
   unit = "s",

--- a/tests/testthat/test-benchmark_parallelDist.R
+++ b/tests/testthat/test-benchmark_parallelDist.R
@@ -22,6 +22,18 @@ test_that("crossdist_parallelDist matches fastDist on small matrices", {
     fdist(A, B, method = "minkowski", p = 3),
     tolerance = 1e-8
   )
+
+  expect_equal(
+    crossdist_parallelDist(A, B, method = "cosine", block_size = 3L),
+    fdist(A, B, method = "cosine"),
+    tolerance = 1e-8
+  )
+
+  expect_equal(
+    crossdist_parallelDist(A, B, method = "supremum", block_size = 3L),
+    fdist(A, B, method = "supremum"),
+    tolerance = 1e-8
+  )
 })
 
 test_that("benchmark_parallelDist returns a summary for each method and B size", {


### PR DESCRIPTION
### Motivation
- Extender el benchmark para comparar todas las distancias implementadas en `fastDist` que tienen un equivalente en `parallelDist`, y cubrir métricas que usan nombres distintos en ambos paquetes (por ejemplo `supremum` → `maximum`).

### Description
- Añadí un mapeo interno ` .parallelDist_method_map()` y la helper ` .supported_parallelDist_methods()` para relacionar nombres de `fastDist` con los esperados por `parallelDist` y filtrar las métricas compatibles.
- Cambié la validación para usar ` .supported_parallelDist_methods()` y añadí la traducción del nombre a `parallel_method` dentro de `crossdist_parallelDist()` antes de llamar a `parallelDist::parDist()`.
- Actualicé `benchmark_parallelDist()` para usar por defecto ` .supported_parallelDist_methods()` como conjunto de métodos y adapté el script de ejemplo en `inst/benchmarks/parallelDist_microbenchmark.R` para aprovechar ese comportamiento predeterminado.
- Amplié los tests en `tests/testthat/test-benchmark_parallelDist.R` para comprobar la equivalencia entre `fastDist` y `parallelDist` también para `cosine` y `supremum` además de las pruebas existentes.

### Testing
- Intenté ejecutar los tests relevantes con `Rscript -e 'testthat::test_file("tests/testthat/test-benchmark_parallelDist.R")'`, pero falló porque `Rscript` no está disponible en este entorno (error: `Rscript: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c66944d8832cb792c22c6cd9e4dd)