### PR TITLE
Add English roxygen documentation for fdist and benchmark functions

### DIFF
--- a/R/benchmark_parallelDist.R
+++ b/R/benchmark_parallelDist.R
@@ -1,3 +1,13 @@
+#' Validate distance method names
+#'
+#' Checks that `method` belongs to the set of supported methods for
+#' `parallelDist` benchmarking.
+#'
+#' @param method Character scalar with the distance method name.
+#'
+#' @return Invisibly returns `NULL`; throws an error if validation fails.
+#' @keywords internal
+#' @noRd
 .validate_distance_method <- function(method) {
   valid_methods <- c("euclidean", "manhattan", "minkowski")
   if (!method %in% valid_methods) {
@@ -8,6 +18,14 @@
   }
 }
 
+#' Ensure benchmark dependencies are available
+#'
+#' Verifies that required benchmarking packages are installed.
+#'
+#' @return Invisibly returns `NULL`; throws an error when dependencies are
+#'   missing.
+#' @keywords internal
+#' @noRd
 .require_benchmark_packages <- function() {
   missing_packages <- c()
 
@@ -30,6 +48,24 @@
   }
 }
 
+#' Compute Cross Distances with `parallelDist` in Blocks
+#'
+#' Computes pairwise distances between rows of `A` and rows of `B` using
+#' `parallelDist::parDist()`, processing `B` by blocks to reduce memory
+#' pressure.
+#'
+#' @param A Numeric matrix (or matrix-like object) of source observations.
+#' @param B Numeric matrix (or matrix-like object) of target observations.
+#' @param method Distance method. Supported values are `"euclidean"`,
+#'   `"manhattan"`, and `"minkowski"`.
+#' @param p Minkowski exponent. Required when `method = "minkowski"`.
+#' @param threads Optional number of threads passed to
+#'   `parallelDist::parDist()`.
+#' @param block_size Number of rows of `B` processed per iteration. If `NULL`,
+#'   defaults to `nrow(A)`.
+#'
+#' @return A numeric matrix of size `nrow(A) x nrow(B)` with cross distances.
+#' @export
 crossdist_parallelDist <- function(A,
                                    B,
                                    method = "euclidean",
@@ -88,6 +124,33 @@ crossdist_parallelDist <- function(A,
   result
 }
 
+#' Benchmark `fastDist` vs `parallelDist`
+#'
+#' Runs benchmarking experiments comparing [`fdist()`] and
+#' [`crossdist_parallelDist()`] across multiple methods and `B` matrix sizes.
+#' Optional correctness checks can verify numerical agreement before timing.
+#'
+#' @param A Optional numeric matrix of source observations. If `NULL`, a random
+#'   matrix is generated.
+#' @param B Optional numeric matrix of target observations. If `NULL`, a random
+#'   matrix is generated.
+#' @param a_nrow Number of rows to generate for `A` when `A` is `NULL`.
+#' @param n_features Number of columns/features for generated matrices.
+#' @param b_sizes Integer vector with the evaluated numbers of rows for `B`.
+#' @param methods Character vector of methods to benchmark. Supported values are
+#'   `"euclidean"`, `"manhattan"`, and `"minkowski"`.
+#' @param minkowski_p Exponent used when benchmarking the Minkowski distance.
+#' @param times Number of repetitions passed to `microbenchmark`.
+#' @param seed Random seed used when generating `A` and `B`.
+#' @param unit Time unit for benchmark results (passed to `microbenchmark`).
+#' @param threads Optional number of threads for `parallelDist`.
+#' @param block_size Optional block size used by [`crossdist_parallelDist()`].
+#' @param check Logical; if `TRUE`, validate that both implementations produce
+#'   equivalent results before timing.
+#'
+#' @return A list with benchmark parameters, a summary table, raw benchmark
+#'   objects, and the matrices used in the benchmark run.
+#' @export
 benchmark_parallelDist <- function(A = NULL,
                                    B = NULL,
                                    a_nrow = 1000L,

--- a/R/fdist.R
+++ b/R/fdist.R
@@ -1,18 +1,18 @@
-#' Distancias rápidas entre observaciones
+#' Fast Distance Computation Between Observations
 #'
-#' Calcula distancias entre filas de `A` y `B` usando una implementación
-#' registrada en `fdistregistry`. Si `method = "mahalanobis"`, el cálculo se
-#' realiza con la firma específica de ese método.
+#' Computes pairwise distances between rows of `A` and `B` using a distance
+#' backend registered in `fdistregistry`. When `method = "mahalanobis"`, the
+#' function dispatches to the method-specific signature that only requires `A`.
 #'
-#' @param A Matriz o estructura coercible a matriz con las observaciones de
-#'   origen (filas).
-#' @param B Matriz o estructura coercible a matriz con las observaciones de
-#'   destino (filas). Si es `NULL`, se usa `A`.
-#' @param method Nombre del método de distancia registrado en `fdistregistry`.
-#' @param p Parámetro adicional para métodos que lo requieren (por ejemplo,
-#'   Minkowski).
+#' @param A A matrix (or object coercible to a matrix) containing source
+#'   observations in rows.
+#' @param B A matrix (or object coercible to a matrix) containing target
+#'   observations in rows. If `NULL`, `A` is used.
+#' @param method The name of a distance method registered in `fdistregistry`.
+#' @param p Optional extra parameter used by methods that require it (for
+#'   example, Minkowski).
 #'
-#' @return Una matriz numérica con las distancias calculadas.
+#' @return A numeric matrix containing computed distances.
 #' @export
 fdist <- function(A, B = NULL, method, p = NULL) {
   if (!method %in% fdistregistry$get_entry_names()) {


### PR DESCRIPTION
### Motivation
- Replace Spanish roxygen comments with English ones to make package documentation consistent and accessible to an English-speaking audience.
- Provide proper roxygen blocks for benchmarking helpers and public benchmark functions so documentation can be generated and internal helpers are clearly marked.

### Description
- Translated and replaced the roxygen block for `fdist()` in `R/fdist.R` with an English description, parameters, and return value.
- Added English roxygen documentation for the internal helpers `.validate_distance_method()` and `.require_benchmark_packages()` in `R/benchmark_parallelDist.R` and marked them `@keywords internal` and `@noRd`.
- Added English roxygen documentation and `@export` for `crossdist_parallelDist()` and `benchmark_parallelDist()` in `R/benchmark_parallelDist.R`, documenting parameters and return values.
- No runtime logic was changed; this PR only updates inline documentation comments.

### Testing
- Attempted to parse the modified files with `Rscript -e "parse(file='R/fdist.R'); parse(file='R/benchmark_parallelDist.R')"`, but the command failed because `Rscript` is not available in the environment.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fa27e554832cbbd93f7903643f79)