### PR TITLE
Fix native symbol resolution in Rcpp wrappers

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,33 +2,33 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 .euclidean <- function(Ar, Br) {
-    .Call(`_fastDist_euclidean`, Ar, Br)
+    .Call("_fastDist_euclidean", Ar, Br, PACKAGE = "fastDist")
 }
 
 .manhattan <- function(Ar, Br) {
-    .Call(`_fastDist_manhattan`, Ar, Br)
+    .Call("_fastDist_manhattan", Ar, Br, PACKAGE = "fastDist")
 }
 
 .minkowski <- function(Ar, Br, p) {
-    .Call(`_fastDist_minkowski`, Ar, Br, p)
+    .Call("_fastDist_minkowski", Ar, Br, p, PACKAGE = "fastDist")
 }
 
 .correlation <- function(Ar, Br) {
-    .Call(`_fastDist_correlation`, Ar, Br)
+    .Call("_fastDist_correlation", Ar, Br, PACKAGE = "fastDist")
 }
 
 .cosine <- function(Ar, Br) {
-    .Call(`_fastDist_cosine`, Ar, Br)
+    .Call("_fastDist_cosine", Ar, Br, PACKAGE = "fastDist")
 }
 
 .canberra <- function(Ar, Br) {
-    .Call(`_fastDist_canberra`, Ar, Br)
+    .Call("_fastDist_canberra", Ar, Br, PACKAGE = "fastDist")
 }
 
 .supremum <- function(Ar, Br) {
-    .Call(`_fastDist_supremum`, Ar, Br)
+    .Call("_fastDist_supremum", Ar, Br, PACKAGE = "fastDist")
 }
 
 .mahalanobis <- function(Ar) {
-    .Call(`_fastDist_mahalanobis`, Ar)
+    .Call("_fastDist_mahalanobis", Ar, PACKAGE = "fastDist")
 }


### PR DESCRIPTION
### Motivation
- Evitar el fallo en tiempo de ejecución `Error in .Call(<pointer: (nil)>, Ar, Br) : NULL value passed as symbol address` causado por resolución de símbolos nativos desde los wrappers generados por Rcpp.

### Description
- Actualiza `R/RcppExports.R` para que todas las funciones wrapper (por ejemplo `.euclidean`, `.manhattan`, `.minkowski`, etc.) invoquen `.Call()` usando el nombre del símbolo como cadena y `PACKAGE = "fastDist"` (por ejemplo `.Call("_fastDist_euclidean", Ar, Br, PACKAGE = "fastDist")`).

### Testing
- Intenté ejecutar una verificación automática con `Rscript` que llamaba a `.euclidean(A, A)`, pero `Rscript` no está instalado en este entorno, por lo que no se pudieron ejecutar pruebas automáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50aa38228832cb8aacd2831227d85)