### PR TITLE
Reinforce native symbol bindings at package load to prevent NULL native addresses

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,20 @@
+# Reinforce native symbol bindings for Rcpp wrappers at load time.
+# This keeps generated R/RcppExports.R untouched while preventing
+# NULL symbol-address errors in environments where bindings are stale.
+.onLoad <- function(libname, pkgname) {
+  ns <- asNamespace(pkgname)
+  symbols <- c(
+    "_fastDist_euclidean",
+    "_fastDist_manhattan",
+    "_fastDist_minkowski",
+    "_fastDist_correlation",
+    "_fastDist_cosine",
+    "_fastDist_canberra",
+    "_fastDist_supremum",
+    "_fastDist_mahalanobis"
+  )
+
+  for (sym in symbols) {
+    assign(sym, getNativeSymbolInfo(sym, PACKAGE = pkgname), envir = ns)
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure native symbol bindings for Rcpp wrappers are (re)established when the package loads to avoid NULL symbol-address errors caused by stale or missing native symbol references.

### Description
- Add `R/zzz.R` implementing `.onLoad` which looks up the `_fastDist_*` native symbols via `getNativeSymbolInfo(..., PACKAGE = pkgname)` and assigns them into the package namespace with `assign`.

### Testing
- Ran the package test suite and `R CMD check --no-manual`, and the `testthat` tests and `R CMD check` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50aa38228832cb8aacd2831227d85)