### PR TITLE
Improve `fdist` roxygen2 documentation with full method definitions and formulas

### DIFF
--- a/R/fdist.R
+++ b/R/fdist.R
@@ -1,18 +1,76 @@
-#' Fast Distance Computation Between Observations
+#' Fast Pairwise Distance Computation Between Observations
 #'
-#' Computes pairwise distances between rows of `A` and `B` using a distance
-#' backend registered in `fdistregistry`. When `method = "mahalanobis"`, the
-#' function dispatches to the method-specific signature that only requires `A`.
+#' Computes pairwise distances between rows of `A` and `B` using distance
+#' backends registered in `fdistregistry`.
 #'
 #' @param A A matrix (or object coercible to a matrix) containing source
 #'   observations in rows.
 #' @param B A matrix (or object coercible to a matrix) containing target
-#'   observations in rows. If `NULL`, `A` is used.
-#' @param method The name of a distance method registered in `fdistregistry`.
-#' @param p Optional extra parameter used by methods that require it (for
-#'   example, Minkowski).
+#'   observations in rows. If `NULL`, `A` is used (except for
+#'   `method = "mahalanobis"`, which always uses only `A`).
+#' @param method Character scalar with the distance method to use. Supported
+#'   values are `"euclidean"`, `"manhattan"`, `"minkowski"`, `"correlation"`,
+#'   `"cosine"`, `"canberra"`, `"supremum"`, and `"mahalanobis"`.
+#' @param p Numeric scalar used only when `method = "minkowski"`. It is the
+#'   exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
+#'   definition).
 #'
-#' @return A numeric matrix containing computed distances.
+#' @details
+#' Let \eqn{x_i = (x_{i1}, \ldots, x_{ik})} be row `i` from `A` and
+#' \eqn{y_j = (y_{j1}, \ldots, y_{jk})} be row `j` from `B`.
+#'
+#' Available `method` values are:
+#'
+#' \describe{
+#'   \item{`"euclidean"`}{
+#'   Standard \eqn{L_2} distance.
+#'   \deqn{d(x_i, y_j) = \sqrt{\sum_{c=1}^{k} (x_{ic} - y_{jc})^2}.}
+#'   }
+#'
+#'   \item{`"manhattan"`}{
+#'   City-block (\eqn{L_1}) distance.
+#'   \deqn{d(x_i, y_j) = \sum_{c=1}^{k} |x_{ic} - y_{jc}|.}
+#'   }
+#'
+#'   \item{`"minkowski"`}{
+#'   Generalized \eqn{L_p} distance controlled by `p`.
+#'   \deqn{d(x_i, y_j) = \left(\sum_{c=1}^{k} |x_{ic} - y_{jc}|^p\right)^{1/p}.}
+#'   Special cases: `p = 1` gives Manhattan and `p = 2` gives Euclidean.
+#'   }
+#'
+#'   \item{`"correlation"`}{
+#'   Correlation distance, defined as one minus the Pearson correlation between
+#'   centered row vectors.
+#'   \deqn{d(x_i, y_j) = 1 - \frac{\sum_{c=1}^{k}(x_{ic}-\bar{x}_i)(y_{jc}-\bar{y}_j)}
+#'   {\sqrt{\sum_{c=1}^{k}(x_{ic}-\bar{x}_i)^2}\sqrt{\sum_{c=1}^{k}(y_{jc}-\bar{y}_j)^2}}.}
+#'   }
+#'
+#'   \item{`"cosine"`}{
+#'   Cosine distance, defined as one minus cosine similarity.
+#'   \deqn{d(x_i, y_j) = 1 - \frac{\sum_{c=1}^{k}x_{ic}y_{jc}}
+#'   {\sqrt{\sum_{c=1}^{k}x_{ic}^2}\sqrt{\sum_{c=1}^{k}y_{jc}^2}}.}
+#'   }
+#'
+#'   \item{`"canberra"`}{
+#'   Canberra distance (feature-wise normalized absolute differences).
+#'   \deqn{d(x_i, y_j) = \sum_{c=1}^{k}\frac{|x_{ic}-y_{jc}|}{|x_{ic}|+|y_{jc}|},}
+#'   where terms with zero denominator contribute `0`.
+#'   }
+#'
+#'   \item{`"supremum"`}{
+#'   Supremum (Chebyshev, \eqn{L_\infty}) distance.
+#'   \deqn{d(x_i, y_j) = \max_{c=1,\ldots,k}|x_{ic}-y_{jc}|.}
+#'   }
+#'
+#'   \item{`"mahalanobis"`}{
+#'   Mahalanobis distance using the sample covariance matrix \eqn{S} estimated
+#'   from `A` (\eqn{B} is ignored).
+#'   \deqn{d(x_i, x_j) = \sqrt{(x_i - x_j)^\top S^{-1}(x_i - x_j)}.}
+#'   }
+#' }
+#'
+#' @return A numeric matrix where entry `[i, j]` is the distance between row
+#'   `i` of `A` and row `j` of `B` (or row `j` of `A` when `B = NULL`).
 #' @export
 fdist <- function(A, B = NULL, method, p = NULL) {
   if (!method %in% fdistregistry$get_entry_names()) {

--- a/man/fdist.Rd
+++ b/man/fdist.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fdist.R
 \name{fdist}
 \alias{fdist}
-\title{Fast Distance Computation Between Observations}
+\title{Fast Pairwise Distance Computation Between Observations}
 \usage{
 fdist(A, B = NULL, method, p = NULL)
 }
@@ -11,18 +11,76 @@ fdist(A, B = NULL, method, p = NULL)
 observations in rows.}
 
 \item{B}{A matrix (or object coercible to a matrix) containing target
-observations in rows. If `NULL`, `A` is used.}
+observations in rows. If `NULL`, `A` is used (except for
+`method = "mahalanobis"`, which always uses only `A`).}
 
-\item{method}{The name of a distance method registered in `fdistregistry`.}
+\item{method}{Character scalar with the distance method to use. Supported
+values are `"euclidean"`, `"manhattan"`, `"minkowski"`, `"correlation"`,
+`"cosine"`, `"canberra"`, `"supremum"`, and `"mahalanobis"`.}
 
-\item{p}{Optional extra parameter used by methods that require it (for
-example, Minkowski).}
+\item{p}{Numeric scalar used only when `method = "minkowski"`. It is the
+exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
+definition).}
 }
 \value{
-A numeric matrix containing computed distances.
+A numeric matrix where entry `[i, j]` is the distance between row
+`i` of `A` and row `j` of `B` (or row `j` of `A` when `B = NULL`).
 }
 \description{
-Computes pairwise distances between rows of `A` and `B` using a distance
-backend registered in `fdistregistry`. When `method = "mahalanobis"`, the
-function dispatches to the method-specific signature that only requires `A`.
+Computes pairwise distances between rows of `A` and `B` using distance
+backends registered in `fdistregistry`.
+}
+\details{
+Let \eqn{x_i = (x_{i1}, \ldots, x_{ik})} be row `i` from `A` and
+\eqn{y_j = (y_{j1}, \ldots, y_{jk})} be row `j` from `B`.
+
+Available `method` values are:
+
+\describe{
+  \item{`"euclidean"`}{
+  Standard \eqn{L_2} distance.
+  \deqn{d(x_i, y_j) = \sqrt{\sum_{c=1}^{k} (x_{ic} - y_{jc})^2}.}
+  }
+
+  \item{`"manhattan"`}{
+  City-block (\eqn{L_1}) distance.
+  \deqn{d(x_i, y_j) = \sum_{c=1}^{k} |x_{ic} - y_{jc}|.}
+  }
+
+  \item{`"minkowski"`}{
+  Generalized \eqn{L_p} distance controlled by `p`.
+  \deqn{d(x_i, y_j) = \left(\sum_{c=1}^{k} |x_{ic} - y_{jc}|^p\right)^{1/p}.}
+  Special cases: `p = 1` gives Manhattan and `p = 2` gives Euclidean.
+  }
+
+  \item{`"correlation"`}{
+  Correlation distance, defined as one minus the Pearson correlation between
+  centered row vectors.
+  \deqn{d(x_i, y_j) = 1 - \frac{\sum_{c=1}^{k}(x_{ic}-\bar{x}_i)(y_{jc}-\bar{y}_j)}
+  {\sqrt{\sum_{c=1}^{k}(x_{ic}-\bar{x}_i)^2}\sqrt{\sum_{c=1}^{k}(y_{jc}-\bar{y}_j)^2}}.}
+  }
+
+  \item{`"cosine"`}{
+  Cosine distance, defined as one minus cosine similarity.
+  \deqn{d(x_i, y_j) = 1 - \frac{\sum_{c=1}^{k}x_{ic}y_{jc}}
+  {\sqrt{\sum_{c=1}^{k}x_{ic}^2}\sqrt{\sum_{c=1}^{k}y_{jc}^2}}.}
+  }
+
+  \item{`"canberra"`}{
+  Canberra distance (feature-wise normalized absolute differences).
+  \deqn{d(x_i, y_j) = \sum_{c=1}^{k}\frac{|x_{ic}-y_{jc}|}{|x_{ic}|+|y_{jc}|},}
+  where terms with zero denominator contribute `0`.
+  }
+
+  \item{`"supremum"`}{
+  Supremum (Chebyshev, \eqn{L_\infty}) distance.
+  \deqn{d(x_i, y_j) = \max_{c=1,\ldots,k}|x_{ic}-y_{jc}|.}
+  }
+
+  \item{`"mahalanobis"`}{
+  Mahalanobis distance using the sample covariance matrix \eqn{S} estimated
+  from `A` (\eqn{B} is ignored).
+  \deqn{d(x_i, x_j) = \sqrt{(x_i - x_j)^\top S^{-1}(x_i - x_j)}.}
+  }
+}
 }


### PR DESCRIPTION
### Motivation
- Provide complete, English roxygen2 documentation for `fdist` so users can see all supported distance methods, their behavior, and mathematical definitions.
- Clarify parameter semantics for `B` and `p`, and explicitly document the special-case behavior of `method = "mahalanobis"`.

### Description
- Expanded the roxygen block in `R/fdist.R` to list supported `method` values and include a one-line purpose plus the mathematical formula for each method (`euclidean`, `manhattan`, `minkowski`, `correlation`, `cosine`, `canberra`, `supremum`, `mahalanobis`).
- Clarified `B` and `p` parameters in the documentation, noting that `B` is ignored for `"mahalanobis"` and that `p` is only used for `"minkowski"` (with the usual `L_p` formula and special cases `p=1` and `p=2`).
- Updated the generated manual page `man/fdist.Rd` to match the new roxygen content; the `Rd` file was edited directly to keep help output consistent in this environment.

### Testing
- Attempted to regenerate documentation with `Rscript -e 'roxygen2::roxygenise()'`, which failed because `Rscript` is not available in the environment (no further automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e664759308832cb65745d3da7c262f)