### PR TITLE
Add Tier 1 distance metrics

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,6 +29,38 @@
     .Call(`_fastDist_supremum`, Ar, Br)
 }
 
+.squared_euclidean <- function(Ar, Br) {
+    .Call(`_fastDist_squared_euclidean`, Ar, Br)
+}
+
+.braycurtis <- function(Ar, Br) {
+    .Call(`_fastDist_braycurtis`, Ar, Br)
+}
+
+.hellinger <- function(Ar, Br) {
+    .Call(`_fastDist_hellinger`, Ar, Br)
+}
+
+.chisquared <- function(Ar, Br) {
+    .Call(`_fastDist_chisquared`, Ar, Br)
+}
+
+.jensenshannon <- function(Ar, Br) {
+    .Call(`_fastDist_jensenshannon`, Ar, Br)
+}
+
+.haversine <- function(Ar, Br) {
+    .Call(`_fastDist_haversine`, Ar, Br)
+}
+
+.standardized_euclidean <- function(Ar, Br) {
+    .Call(`_fastDist_standardized_euclidean`, Ar, Br)
+}
+
+.spearman <- function(Ar, Br) {
+    .Call(`_fastDist_spearman`, Ar, Br)
+}
+
 .mahalanobis <- function(Ar) {
     .Call(`_fastDist_mahalanobis`, Ar)
 }

--- a/R/fastDist_cpp_docs.R
+++ b/R/fastDist_cpp_docs.R
@@ -141,6 +141,167 @@ NULL
 #' @noRd
 NULL
 
+#' Internal squared Euclidean distance backend (.squared_euclidean)
+#'
+#' @name .squared_euclidean
+#' @description
+#' Computes the squared Euclidean distance between rows of `Ar` and `Br`.
+#' @details
+#' For observations \eqn{x, y \in \mathbb{R}^k}:
+#' \deqn{d(x, y) = \sum_{i=1}^{k}(x_i - y_i)^2}
+#' This is the Euclidean distance without the final square root, computed via
+#' the identity \eqn{(x - y)^2 = x^2 - 2xy + y^2}.
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @inheritParams .euclidean
+#'
+#' @return Numeric `m x n` matrix with pairwise distances.
+#' @usage .squared_euclidean(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
+#' Internal Bray-Curtis distance backend (.braycurtis)
+#'
+#' @name .braycurtis
+#' @description
+#' Computes the Bray-Curtis dissimilarity between rows of `Ar` and `Br`.
+#' @details
+#' For observations \eqn{x, y \in \mathbb{R}^k}:
+#' \deqn{d(x, y) = \frac{\sum_{i=1}^{k}|x_i - y_i|}{\sum_{i=1}^{k}|x_i + y_i|}}
+#' A zero denominator yields a distance of `0`.
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @inheritParams .euclidean
+#'
+#' @return Numeric `m x n` matrix with pairwise distances.
+#' @usage .braycurtis(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
+#' Internal Hellinger distance backend (.hellinger)
+#'
+#' @name .hellinger
+#' @description
+#' Computes the Hellinger distance between rows of `Ar` and `Br`. Inputs are
+#' assumed to be non-negative.
+#' @details
+#' For non-negative observations \eqn{x, y \in \mathbb{R}^k}:
+#' \deqn{d(x, y) = \frac{1}{\sqrt{2}}
+#' \sqrt{\sum_{i=1}^{k}(\sqrt{x_i} - \sqrt{y_i})^2}}
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @inheritParams .euclidean
+#'
+#' @return Numeric `m x n` matrix with pairwise distances.
+#' @usage .hellinger(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
+#' Internal chi-squared distance backend (.chisquared)
+#'
+#' @name .chisquared
+#' @description
+#' Computes the symmetric chi-squared distance between rows of `Ar` and `Br`.
+#' @details
+#' For observations \eqn{x, y \in \mathbb{R}^k}:
+#' \deqn{d(x, y) = \frac{1}{2}\sum_{i=1}^{k}\frac{(x_i - y_i)^2}{x_i + y_i}}
+#' Terms with a zero denominator are skipped.
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @inheritParams .euclidean
+#'
+#' @return Numeric `m x n` matrix with pairwise distances.
+#' @usage .chisquared(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
+#' Internal Jensen-Shannon distance backend (.jensenshannon)
+#'
+#' @name .jensenshannon
+#' @description
+#' Computes the Jensen-Shannon distance between rows of `Ar` and `Br`. Each row
+#' is normalized to sum to one before the computation.
+#' @details
+#' Let \eqn{m = (x + y)/2}. The Jensen-Shannon distance is the square root of the
+#' Jensen-Shannon divergence (natural logarithm):
+#' \deqn{d(x, y) = \sqrt{\tfrac{1}{2}\sum_i x_i\log\frac{x_i}{m_i}
+#' + \tfrac{1}{2}\sum_i y_i\log\frac{y_i}{m_i}}}
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @inheritParams .euclidean
+#'
+#' @return Numeric `m x n` matrix with pairwise distances.
+#' @usage .jensenshannon(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
+#' Internal Haversine distance backend (.haversine)
+#'
+#' @name .haversine
+#' @description
+#' Computes the great-circle (Haversine) distance in kilometres between rows of
+#' `Ar` and `Br`. Both matrices must have exactly two columns holding latitude
+#' and longitude in degrees.
+#' @details
+#' With latitudes/longitudes in radians and Earth radius \eqn{R = 6371} km:
+#' \deqn{a = \sin^2\!\big(\tfrac{\Delta\phi}{2}\big)
+#' + \cos\phi_1\cos\phi_2\sin^2\!\big(\tfrac{\Delta\lambda}{2}\big),\quad
+#' d = 2R\,\mathrm{asin}(\sqrt{a})}
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @param Ar Numeric matrix of size `m x 2` with `(latitude, longitude)` rows.
+#' @param Br Numeric matrix of size `n x 2` with `(latitude, longitude)` rows.
+#'
+#' @return Numeric `m x n` matrix with pairwise distances in kilometres.
+#' @usage .haversine(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
+#' Internal standardized Euclidean distance backend (.standardized_euclidean)
+#'
+#' @name .standardized_euclidean
+#' @description
+#' Computes the standardized Euclidean distance between rows of `Ar` and `Br`,
+#' scaling each feature by its sample variance estimated from `Ar`.
+#' @details
+#' Let \eqn{s_c^2} be the sample variance of column `c` of `Ar`. Then:
+#' \deqn{d(x, y) = \sqrt{\sum_{c=1}^{k}\frac{(x_c - y_c)^2}{s_c^2}}}
+#' Features with zero variance are dropped.
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @inheritParams .euclidean
+#'
+#' @return Numeric `m x n` matrix with pairwise distances.
+#' @usage .standardized_euclidean(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
+#' Internal Spearman correlation distance backend (.spearman)
+#'
+#' @name .spearman
+#' @description
+#' Computes the Spearman correlation distance between rows of `Ar` and `Br`.
+#' @details
+#' Each row is replaced by its within-row average ranks, and the Pearson
+#' correlation \eqn{\rho_s} is computed on those ranks:
+#' \deqn{d(x, y) = 1 - \rho_s(x, y)}
+#' This function is an internal backend implemented in C++ and exposed via Rcpp.
+#'
+#' @inheritParams .euclidean
+#'
+#' @return Numeric `m x n` matrix with pairwise distances.
+#' @usage .spearman(Ar, Br)
+#' @keywords internal
+#' @noRd
+NULL
+
 #' Internal Mahalanobis distance backend (.mahalanobis)
 #'
 #' @name .mahalanobis

--- a/R/fdist.R
+++ b/R/fdist.R
@@ -10,7 +10,10 @@
 #'   `method = "mahalanobis"`, which always uses only `A`).
 #' @param method Character scalar with the distance method to use. Supported
 #'   values are `"euclidean"`, `"manhattan"`, `"minkowski"`, `"correlation"`,
-#'   `"cosine"`, `"canberra"`, `"supremum"`, and `"mahalanobis"`.
+#'   `"cosine"`, `"canberra"`, `"supremum"`, `"squared_euclidean"`,
+#'   `"bray_curtis"`, `"hellinger"`, `"chi_squared"`, `"jensen_shannon"`,
+#'   `"haversine"`, `"standardized_euclidean"`, `"spearman"`, and
+#'   `"mahalanobis"`.
 #' @param p Numeric scalar used only when `method = "minkowski"`. It is the
 #'   exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
 #'   definition).
@@ -60,6 +63,59 @@
 #'   \item{`"supremum"`}{
 #'   Supremum (Chebyshev, \eqn{L_\infty}) distance.
 #'   \deqn{d(x_i, y_j) = \max_{c=1,\ldots,k}|x_{ic}-y_{jc}|.}
+#'   }
+#'
+#'   \item{`"squared_euclidean"`}{
+#'   Squared Euclidean distance (Euclidean without the final square root),
+#'   useful for clustering algorithms such as k-means.
+#'   \deqn{d(x_i, y_j) = \sum_{c=1}^{k} (x_{ic} - y_{jc})^2.}
+#'   }
+#'
+#'   \item{`"bray_curtis"`}{
+#'   Bray-Curtis dissimilarity, common for abundance/compositional data.
+#'   \deqn{d(x_i, y_j) = \frac{\sum_{c=1}^{k}|x_{ic}-y_{jc}|}
+#'   {\sum_{c=1}^{k}|x_{ic}+y_{jc}|},}
+#'   where a zero denominator yields `0`.
+#'   }
+#'
+#'   \item{`"hellinger"`}{
+#'   Hellinger distance between non-negative vectors (e.g. distributions).
+#'   \deqn{d(x_i, y_j) = \frac{1}{\sqrt{2}}
+#'   \sqrt{\sum_{c=1}^{k}(\sqrt{x_{ic}}-\sqrt{y_{jc}})^2}.}
+#'   }
+#'
+#'   \item{`"chi_squared"`}{
+#'   Symmetric chi-squared distance for histograms / non-negative data.
+#'   \deqn{d(x_i, y_j) = \frac{1}{2}\sum_{c=1}^{k}
+#'   \frac{(x_{ic}-y_{jc})^2}{x_{ic}+y_{jc}},}
+#'   where terms with zero denominator contribute `0`.
+#'   }
+#'
+#'   \item{`"jensen_shannon"`}{
+#'   Jensen-Shannon distance (square root of the Jensen-Shannon divergence,
+#'   natural logarithm). Each row is normalized to sum to one beforehand. With
+#'   \eqn{m = (x_i + y_j)/2},
+#'   \deqn{d(x_i, y_j) = \sqrt{\tfrac{1}{2}\!\sum_c x_{ic}\log\frac{x_{ic}}{m_c}
+#'   + \tfrac{1}{2}\!\sum_c y_{jc}\log\frac{y_{jc}}{m_c}}.}
+#'   }
+#'
+#'   \item{`"haversine"`}{
+#'   Great-circle distance in kilometres between points given as
+#'   `(latitude, longitude)` in degrees (requires exactly two columns; Earth
+#'   radius 6371 km).
+#'   }
+#'
+#'   \item{`"standardized_euclidean"`}{
+#'   Euclidean distance with each feature scaled by its sample variance
+#'   \eqn{s_c^2} estimated from `A`.
+#'   \deqn{d(x_i, y_j) = \sqrt{\sum_{c=1}^{k}\frac{(x_{ic}-y_{jc})^2}{s_c^2}},}
+#'   where features with zero variance are dropped.
+#'   }
+#'
+#'   \item{`"spearman"`}{
+#'   Spearman correlation distance, i.e. one minus Spearman's rank correlation
+#'   computed between the within-row average ranks of `x_i` and `y_j`.
+#'   \deqn{d(x_i, y_j) = 1 - \rho_s(x_i, y_j).}
 #'   }
 #'
 #'   \item{`"mahalanobis"`}{

--- a/R/registry.R
+++ b/R/registry.R
@@ -41,7 +41,39 @@ fdistregistry$set_entry(method = "supremum",
                         fun    = .supremum,
                         description = "supremum distance")
 
-fdistregistry$set_entry(method = "mahalanobis",  
+fdistregistry$set_entry(method = "squared_euclidean",
+                        fun    = .squared_euclidean,
+                        description = "squared Euclidean distance")
+
+fdistregistry$set_entry(method = "bray_curtis",
+                        fun    = .braycurtis,
+                        description = "Bray-Curtis distance")
+
+fdistregistry$set_entry(method = "hellinger",
+                        fun    = .hellinger,
+                        description = "Hellinger distance")
+
+fdistregistry$set_entry(method = "chi_squared",
+                        fun    = .chisquared,
+                        description = "chi-squared distance")
+
+fdistregistry$set_entry(method = "jensen_shannon",
+                        fun    = .jensenshannon,
+                        description = "Jensen-Shannon distance")
+
+fdistregistry$set_entry(method = "haversine",
+                        fun    = .haversine,
+                        description = "Haversine (great-circle) distance")
+
+fdistregistry$set_entry(method = "standardized_euclidean",
+                        fun    = .standardized_euclidean,
+                        description = "standardized Euclidean distance")
+
+fdistregistry$set_entry(method = "spearman",
+                        fun    = .spearman,
+                        description = "Spearman correlation distance")
+
+fdistregistry$set_entry(method = "mahalanobis",
                         fun    = .mahalanobis,
                         description = "Mahalanobis distance")
 

--- a/man/fdist.Rd
+++ b/man/fdist.Rd
@@ -16,7 +16,10 @@ observations in rows. If `NULL`, `A` is used (except for
 
 \item{method}{Character scalar with the distance method to use. Supported
 values are `"euclidean"`, `"manhattan"`, `"minkowski"`, `"correlation"`,
-`"cosine"`, `"canberra"`, `"supremum"`, and `"mahalanobis"`.}
+`"cosine"`, `"canberra"`, `"supremum"`, `"squared_euclidean"`,
+`"bray_curtis"`, `"hellinger"`, `"chi_squared"`, `"jensen_shannon"`,
+`"haversine"`, `"standardized_euclidean"`, `"spearman"`, and
+`"mahalanobis"`.}
 
 \item{p}{Numeric scalar used only when `method = "minkowski"`. It is the
 exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
@@ -75,6 +78,59 @@ Available `method` values are:
   \item{`"supremum"`}{
   Supremum (Chebyshev, \eqn{L_\infty}) distance.
   \deqn{d(x_i, y_j) = \max_{c=1,\ldots,k}|x_{ic}-y_{jc}|.}
+  }
+
+  \item{`"squared_euclidean"`}{
+  Squared Euclidean distance (Euclidean without the final square root),
+  useful for clustering algorithms such as k-means.
+  \deqn{d(x_i, y_j) = \sum_{c=1}^{k} (x_{ic} - y_{jc})^2.}
+  }
+
+  \item{`"bray_curtis"`}{
+  Bray-Curtis dissimilarity, common for abundance/compositional data.
+  \deqn{d(x_i, y_j) = \frac{\sum_{c=1}^{k}|x_{ic}-y_{jc}|}
+  {\sum_{c=1}^{k}|x_{ic}+y_{jc}|},}
+  where a zero denominator yields `0`.
+  }
+
+  \item{`"hellinger"`}{
+  Hellinger distance between non-negative vectors (e.g. distributions).
+  \deqn{d(x_i, y_j) = \frac{1}{\sqrt{2}}
+  \sqrt{\sum_{c=1}^{k}(\sqrt{x_{ic}}-\sqrt{y_{jc}})^2}.}
+  }
+
+  \item{`"chi_squared"`}{
+  Symmetric chi-squared distance for histograms / non-negative data.
+  \deqn{d(x_i, y_j) = \frac{1}{2}\sum_{c=1}^{k}
+  \frac{(x_{ic}-y_{jc})^2}{x_{ic}+y_{jc}},}
+  where terms with zero denominator contribute `0`.
+  }
+
+  \item{`"jensen_shannon"`}{
+  Jensen-Shannon distance (square root of the Jensen-Shannon divergence,
+  natural logarithm). Each row is normalized to sum to one beforehand. With
+  \eqn{m = (x_i + y_j)/2},
+  \deqn{d(x_i, y_j) = \sqrt{\tfrac{1}{2}\!\sum_c x_{ic}\log\frac{x_{ic}}{m_c}
+  + \tfrac{1}{2}\!\sum_c y_{jc}\log\frac{y_{jc}}{m_c}}.}
+  }
+
+  \item{`"haversine"`}{
+  Great-circle distance in kilometres between points given as
+  `(latitude, longitude)` in degrees (requires exactly two columns; Earth
+  radius 6371 km).
+  }
+
+  \item{`"standardized_euclidean"`}{
+  Euclidean distance with each feature scaled by its sample variance
+  \eqn{s_c^2} estimated from `A`.
+  \deqn{d(x_i, y_j) = \sqrt{\sum_{c=1}^{k}\frac{(x_{ic}-y_{jc})^2}{s_c^2}},}
+  where features with zero variance are dropped.
+  }
+
+  \item{`"spearman"`}{
+  Spearman correlation distance, i.e. one minus Spearman's rank correlation
+  computed between the within-row average ranks of `x_i` and `y_j`.
+  \deqn{d(x_i, y_j) = 1 - \rho_s(x_i, y_j).}
   }
 
   \item{`"mahalanobis"`}{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -96,6 +96,102 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// squared_euclidean
+NumericMatrix squared_euclidean(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_squared_euclidean(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(squared_euclidean(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
+// braycurtis
+NumericMatrix braycurtis(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_braycurtis(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(braycurtis(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
+// hellinger
+NumericMatrix hellinger(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_hellinger(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(hellinger(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
+// chisquared
+NumericMatrix chisquared(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_chisquared(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(chisquared(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
+// jensenshannon
+NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_jensenshannon(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(jensenshannon(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
+// haversine
+NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_haversine(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(haversine(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
+// standardized_euclidean
+NumericMatrix standardized_euclidean(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_standardized_euclidean(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(standardized_euclidean(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
+// spearman
+NumericMatrix spearman(NumericMatrix Ar, NumericMatrix Br);
+RcppExport SEXP _fastDist_spearman(SEXP ArSEXP, SEXP BrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
+    rcpp_result_gen = Rcpp::wrap(spearman(Ar, Br));
+    return rcpp_result_gen;
+END_RCPP
+}
 // mahalanobis
 NumericMatrix mahalanobis(NumericMatrix Ar);
 RcppExport SEXP _fastDist_mahalanobis(SEXP ArSEXP) {
@@ -116,6 +212,14 @@ static const R_CallMethodDef CallEntries[] = {
     {"_fastDist_cosine", (DL_FUNC) &_fastDist_cosine, 2},
     {"_fastDist_canberra", (DL_FUNC) &_fastDist_canberra, 2},
     {"_fastDist_supremum", (DL_FUNC) &_fastDist_supremum, 2},
+    {"_fastDist_squared_euclidean", (DL_FUNC) &_fastDist_squared_euclidean, 2},
+    {"_fastDist_braycurtis", (DL_FUNC) &_fastDist_braycurtis, 2},
+    {"_fastDist_hellinger", (DL_FUNC) &_fastDist_hellinger, 2},
+    {"_fastDist_chisquared", (DL_FUNC) &_fastDist_chisquared, 2},
+    {"_fastDist_jensenshannon", (DL_FUNC) &_fastDist_jensenshannon, 2},
+    {"_fastDist_haversine", (DL_FUNC) &_fastDist_haversine, 2},
+    {"_fastDist_standardized_euclidean", (DL_FUNC) &_fastDist_standardized_euclidean, 2},
+    {"_fastDist_spearman", (DL_FUNC) &_fastDist_spearman, 2},
     {"_fastDist_mahalanobis", (DL_FUNC) &_fastDist_mahalanobis, 1},
     {NULL, NULL, 0}
 };

--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -2,6 +2,7 @@
 #include <Rmath.h>
 #include <algorithm>
 #include <cmath>
+#include <vector>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -417,6 +418,504 @@ NumericMatrix supremum(NumericMatrix Ar, NumericMatrix Br) {
   return wrap(res);
   
   
+}
+
+
+// squared euclidean distance
+// [[Rcpp::export(.squared_euclidean)]]
+NumericMatrix squared_euclidean(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+
+  arma::colvec An = arma::sum(arma::square(A), 1);
+  arma::colvec Bn = arma::sum(arma::square(B), 1);
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      const double ai_norm = An[i];
+      for (int j = i; j < m; j++) {
+        const double* a = Ap + i;
+        const double* b = Bp + j;
+        double dot = 0.0;
+        for (int col = 0; col < k; col++) {
+          dot += (*a) * (*b);
+          a += m;
+          b += n;
+        }
+        double sqDist = ai_norm + Bn[j] - 2.0 * dot;
+        if (sqDist < 0.0) sqDist = 0.0;
+        res(i, j) = sqDist;
+        if (i != j) res(j, i) = sqDist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      const double ai_norm = An[i];
+      for (int j = 0; j < n; j++) {
+        const double* a = Ap + i;
+        const double* b = Bp + j;
+        double dot = 0.0;
+        for (int col = 0; col < k; col++) {
+          dot += (*a) * (*b);
+          a += m;
+          b += n;
+        }
+        double sqDist = ai_norm + Bn[j] - 2.0 * dot;
+        if (sqDist < 0.0) sqDist = 0.0;
+        res(i, j) = sqDist;
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
+// bray-curtis distance
+// [[Rcpp::export(.braycurtis)]]
+NumericMatrix braycurtis(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        double num = 0.0, den = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double a = Ap[col * m + i];
+          const double b = Bp[col * n + j];
+          num += std::abs(a - b);
+          den += std::abs(a + b);
+        }
+        const double dist = den > 0.0 ? num / den : 0.0;
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        double num = 0.0, den = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double a = Ap[col * m + i];
+          const double b = Bp[col * n + j];
+          num += std::abs(a - b);
+          den += std::abs(a + b);
+        }
+        res(i, j) = den > 0.0 ? num / den : 0.0;
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
+// hellinger distance
+// [[Rcpp::export(.hellinger)]]
+NumericMatrix hellinger(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+
+  // precompute element-wise square roots (inputs are assumed non-negative)
+  arma::mat sqrtA = arma::sqrt(A);
+  arma::mat sqrtB = arma::sqrt(B);
+  const double* Ap = sqrtA.memptr();
+  const double* Bp = sqrtB.memptr();
+  const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double delta = Ap[col * m + i] - Bp[col * n + j];
+          acc += delta * delta;
+        }
+        const double dist = inv_sqrt2 * std::sqrt(acc);
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double delta = Ap[col * m + i] - Bp[col * n + j];
+          acc += delta * delta;
+        }
+        res(i, j) = inv_sqrt2 * std::sqrt(acc);
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
+// chi-squared distance
+// [[Rcpp::export(.chisquared)]]
+NumericMatrix chisquared(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double a = Ap[col * m + i];
+          const double b = Bp[col * n + j];
+          const double den = a + b;
+          if (den != 0.0) {
+            const double delta = a - b;
+            acc += (delta * delta) / den;
+          }
+        }
+        const double dist = 0.5 * acc;
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double a = Ap[col * m + i];
+          const double b = Bp[col * n + j];
+          const double den = a + b;
+          if (den != 0.0) {
+            const double delta = a - b;
+            acc += (delta * delta) / den;
+          }
+        }
+        res(i, j) = 0.5 * acc;
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
+// jensen-shannon distance
+// [[Rcpp::export(.jensenshannon)]]
+NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+
+  // normalise each row to a probability distribution (sum to 1)
+  arma::colvec sumA = arma::sum(A, 1);
+  arma::colvec sumB = arma::sum(B, 1);
+  arma::mat P = A;
+  arma::mat Q = B;
+  for (int i = 0; i < m; i++) if (sumA[i] != 0.0) P.row(i) /= sumA[i];
+  for (int j = 0; j < n; j++) if (sumB[j] != 0.0) Q.row(j) /= sumB[j];
+  const double* Pp = P.memptr();
+  const double* Qp = Q.memptr();
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double p = Pp[col * m + i];
+          const double q = Qp[col * n + j];
+          const double mid = 0.5 * (p + q);
+          if (p > 0.0) acc += 0.5 * p * std::log(p / mid);
+          if (q > 0.0) acc += 0.5 * q * std::log(q / mid);
+        }
+        if (acc < 0.0) acc = 0.0;
+        const double dist = std::sqrt(acc);
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double p = Pp[col * m + i];
+          const double q = Qp[col * n + j];
+          const double mid = 0.5 * (p + q);
+          if (p > 0.0) acc += 0.5 * p * std::log(p / mid);
+          if (q > 0.0) acc += 0.5 * q * std::log(q / mid);
+        }
+        if (acc < 0.0) acc = 0.0;
+        res(i, j) = std::sqrt(acc);
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
+// haversine (great-circle) distance, in kilometres
+// [[Rcpp::export(.haversine)]]
+NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  if (k != 2) {
+    stop("haversine distance requires exactly 2 columns (latitude, longitude in degrees)");
+  }
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+  const double deg2rad = M_PI / 180.0;
+  const double R = 6371.0; // mean Earth radius in km
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      const double lat1 = Ap[i] * deg2rad;
+      const double lon1 = Ap[m + i] * deg2rad;
+      for (int j = i; j < m; j++) {
+        const double lat2 = Bp[j] * deg2rad;
+        const double lon2 = Bp[n + j] * deg2rad;
+        const double dlat = lat2 - lat1;
+        const double dlon = lon2 - lon1;
+        const double sdlat = std::sin(dlat * 0.5);
+        const double sdlon = std::sin(dlon * 0.5);
+        double a = sdlat * sdlat + std::cos(lat1) * std::cos(lat2) * sdlon * sdlon;
+        if (a > 1.0) a = 1.0;
+        const double dist = 2.0 * R * std::asin(std::sqrt(a));
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      const double lat1 = Ap[i] * deg2rad;
+      const double lon1 = Ap[m + i] * deg2rad;
+      for (int j = 0; j < n; j++) {
+        const double lat2 = Bp[j] * deg2rad;
+        const double lon2 = Bp[n + j] * deg2rad;
+        const double dlat = lat2 - lat1;
+        const double dlon = lon2 - lon1;
+        const double sdlat = std::sin(dlat * 0.5);
+        const double sdlon = std::sin(dlon * 0.5);
+        double a = sdlat * sdlat + std::cos(lat1) * std::cos(lat2) * sdlon * sdlon;
+        if (a > 1.0) a = 1.0;
+        res(i, j) = 2.0 * R * std::asin(std::sqrt(a));
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
+// standardized euclidean distance
+// (each feature scaled by its sample variance, estimated from A)
+// [[Rcpp::export(.standardized_euclidean)]]
+NumericMatrix standardized_euclidean(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+  const double* Ap = A.memptr();
+  const double* Bp = B.memptr();
+
+  // per-feature sample variance from A (n-1 denominator)
+  arma::rowvec var = arma::var(A, 0, 0);
+  arma::vec inv_var(k);
+  for (int col = 0; col < k; col++) {
+    inv_var[col] = var[col] > 0.0 ? 1.0 / var[col] : 0.0;
+  }
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double delta = Ap[col * m + i] - Bp[col * n + j];
+          acc += delta * delta * inv_var[col];
+        }
+        const double dist = std::sqrt(acc);
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        double acc = 0.0;
+        for (int col = 0; col < k; col++) {
+          const double delta = Ap[col * m + i] - Bp[col * n + j];
+          acc += delta * delta * inv_var[col];
+        }
+        res(i, j) = std::sqrt(acc);
+      }
+    }
+  }
+
+  return wrap(res);
+}
+
+
+// helper: average ranks (1-based) of every row of M, returned with the same
+// column-major layout as M
+inline arma::mat row_ranks(const arma::mat& M) {
+  const int rows = M.n_rows;
+  const int cols = M.n_cols;
+  arma::mat R(rows, cols);
+#pragma omp parallel for schedule(static) if(rows > 100)
+  for (int i = 0; i < rows; i++) {
+    std::vector<int> idx(cols);
+    for (int c = 0; c < cols; c++) idx[c] = c;
+    std::sort(idx.begin(), idx.end(),
+              [&](int a, int b) { return M(i, a) < M(i, b); });
+    int c = 0;
+    while (c < cols) {
+      int j = c;
+      while (j + 1 < cols && M(i, idx[j + 1]) == M(i, idx[c])) j++;
+      const double avg = ((c + 1) + (j + 1)) / 2.0;
+      for (int t = c; t <= j; t++) R(i, idx[t]) = avg;
+      c = j + 1;
+    }
+  }
+  return R;
+}
+
+// spearman correlation distance (1 - Spearman's rho)
+// [[Rcpp::export(.spearman)]]
+NumericMatrix spearman(NumericMatrix Ar, NumericMatrix Br) {
+  int m = Ar.nrow(),
+    n = Br.nrow(),
+    k = Ar.ncol();
+  arma::mat A = arma::mat(Ar.begin(), m, k, false);
+  arma::mat B = arma::mat(Br.begin(), n, k, false);
+  arma::mat res = arma::mat(m, n, arma::fill::zeros);
+  const bool symmetric = same_input(Ar, Br);
+
+  // ranks within each row, then Pearson correlation on the ranks
+  arma::mat RA = row_ranks(A);
+  arma::mat RB = symmetric ? RA : row_ranks(B);
+  const double* Ap = RA.memptr();
+  const double* Bp = RB.memptr();
+  arma::colvec meanA = arma::mean(RA, 1);
+  arma::colvec meanB = arma::mean(RB, 1);
+  arma::colvec normA(m, arma::fill::zeros);
+  arma::colvec normB(n, arma::fill::zeros);
+
+#pragma omp parallel for schedule(static) if(m > 100)
+  for (int i = 0; i < m; i++) {
+    double ss = 0.0;
+    for (int col = 0; col < k; col++) {
+      const double centered = Ap[col * m + i] - meanA[i];
+      ss += centered * centered;
+    }
+    normA[i] = std::sqrt(ss);
+  }
+
+#pragma omp parallel for schedule(static) if(n > 100)
+  for (int j = 0; j < n; j++) {
+    double ss = 0.0;
+    for (int col = 0; col < k; col++) {
+      const double centered = Bp[col * n + j] - meanB[j];
+      ss += centered * centered;
+    }
+    normB[j] = std::sqrt(ss);
+  }
+
+  if (symmetric) {
+#pragma omp parallel for schedule(static) if(m * m > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = i; j < m; j++) {
+        double rho = 0.0;
+        const double denom = normA[i] * normB[j];
+        if (denom > 0.0) {
+          double dot = 0.0;
+          for (int col = 0; col < k; col++) {
+            const double a = Ap[col * m + i] - meanA[i];
+            const double b = Bp[col * n + j] - meanB[j];
+            dot += a * b;
+          }
+          rho = dot / denom;
+          rho = std::max(-1.0, std::min(1.0, rho));
+        }
+        const double dist = 1.0 - rho;
+        res(i, j) = dist;
+        if (i != j) res(j, i) = dist;
+      }
+    }
+  } else {
+#pragma omp parallel for schedule(static) if(m * n > 10000)
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        double rho = 0.0;
+        const double denom = normA[i] * normB[j];
+        if (denom > 0.0) {
+          double dot = 0.0;
+          for (int col = 0; col < k; col++) {
+            const double a = Ap[col * m + i] - meanA[i];
+            const double b = Bp[col * n + j] - meanB[j];
+            dot += a * b;
+          }
+          rho = dot / denom;
+          rho = std::max(-1.0, std::min(1.0, rho));
+        }
+        res(i, j) = 1.0 - rho;
+      }
+    }
+  }
+
+  return wrap(res);
 }
 
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(fastDist)
+
+test_check("fastDist")

--- a/tests/testthat/test-new-metrics.R
+++ b/tests/testthat/test-new-metrics.R
@@ -1,0 +1,121 @@
+# Validation of the Tier 1 distance backends against base-R references.
+
+# Generic pairwise distance using a per-pair function f(x, y).
+pairwise <- function(A, B, f) {
+  A <- as.matrix(A)
+  B <- as.matrix(B)
+  m <- nrow(A)
+  n <- nrow(B)
+  R <- matrix(0, m, n)
+  for (i in seq_len(m)) {
+    for (j in seq_len(n)) {
+      R[i, j] <- f(A[i, ], B[j, ])
+    }
+  }
+  R
+}
+
+set.seed(42)
+# general numeric data (can be negative)
+A <- matrix(rnorm(5 * 4), 5, 4)
+B <- matrix(rnorm(3 * 4), 3, 4)
+
+# strictly positive data for distribution / abundance metrics
+Ap <- matrix(runif(5 * 4, 0.1, 5), 5, 4)
+Bp <- matrix(runif(3 * 4, 0.1, 5), 3, 4)
+
+tol <- 1e-8
+
+test_that("squared_euclidean matches sum of squared differences", {
+  ref <- pairwise(A, B, function(x, y) sum((x - y)^2))
+  expect_equal(fdist(A, B, method = "squared_euclidean"), ref, tolerance = tol)
+  # equals the square of the euclidean distance
+  expect_equal(fdist(A, B, method = "squared_euclidean"),
+               fdist(A, B, method = "euclidean")^2, tolerance = tol)
+})
+
+test_that("bray_curtis matches reference", {
+  bc <- function(x, y) {
+    den <- sum(abs(x + y))
+    if (den == 0) 0 else sum(abs(x - y)) / den
+  }
+  ref <- pairwise(Ap, Bp, bc)
+  expect_equal(fdist(Ap, Bp, method = "bray_curtis"), ref, tolerance = tol)
+})
+
+test_that("hellinger matches reference", {
+  hl <- function(x, y) sqrt(sum((sqrt(x) - sqrt(y))^2)) / sqrt(2)
+  ref <- pairwise(Ap, Bp, hl)
+  expect_equal(fdist(Ap, Bp, method = "hellinger"), ref, tolerance = tol)
+})
+
+test_that("chi_squared matches reference", {
+  cs <- function(x, y) {
+    s <- x + y
+    keep <- s != 0
+    0.5 * sum((x[keep] - y[keep])^2 / s[keep])
+  }
+  ref <- pairwise(Ap, Bp, cs)
+  expect_equal(fdist(Ap, Bp, method = "chi_squared"), ref, tolerance = tol)
+})
+
+test_that("jensen_shannon matches reference and is zero on the diagonal", {
+  js <- function(x, y) {
+    x <- x / sum(x)
+    y <- y / sum(y)
+    m <- 0.5 * (x + y)
+    kl <- function(p) sum(ifelse(p > 0, p * log(p / m), 0))
+    sqrt(0.5 * kl(x) + 0.5 * kl(y))
+  }
+  ref <- pairwise(Ap, Bp, js)
+  expect_equal(fdist(Ap, Bp, method = "jensen_shannon"), ref, tolerance = tol)
+  d <- fdist(Ap, method = "jensen_shannon")
+  expect_equal(diag(d), rep(0, nrow(Ap)), tolerance = tol)
+})
+
+test_that("haversine matches reference and requires two columns", {
+  G1 <- matrix(c(40.4168, -3.7038,   # Madrid
+                 41.3851,  2.1734,   # Barcelona
+                 51.5074, -0.1278),  # London
+               ncol = 2, byrow = TRUE)
+  G2 <- matrix(c(48.8566, 2.3522),   # Paris
+               ncol = 2, byrow = TRUE)
+  hv <- function(x, y) {
+    R <- 6371.0
+    p <- pi / 180
+    dlat <- (y[1] - x[1]) * p
+    dlon <- (y[2] - x[2]) * p
+    a <- sin(dlat / 2)^2 +
+      cos(x[1] * p) * cos(y[1] * p) * sin(dlon / 2)^2
+    2 * R * asin(sqrt(min(a, 1)))
+  }
+  ref <- pairwise(G1, G2, hv)
+  expect_equal(fdist(G1, G2, method = "haversine"), ref, tolerance = 1e-6)
+  # Madrid -> Paris is roughly 1050 km
+  expect_true(abs(fdist(G1, G2, method = "haversine")[1, 1] - 1054) < 20)
+  expect_error(fdist(A, B, method = "haversine"))
+})
+
+test_that("standardized_euclidean matches reference", {
+  v <- apply(A, 2, var)
+  se <- function(x, y) sqrt(sum((x - y)^2 / v))
+  ref <- pairwise(A, B, se)
+  expect_equal(fdist(A, B, method = "standardized_euclidean"), ref, tolerance = tol)
+})
+
+test_that("spearman matches 1 - rank correlation", {
+  sp <- function(x, y) 1 - cor(x, y, method = "spearman")
+  ref <- pairwise(A, B, sp)
+  expect_equal(fdist(A, B, method = "spearman"), ref, tolerance = tol)
+})
+
+test_that("symmetric calls return symmetric matrices with zero diagonal", {
+  for (m in c("squared_euclidean", "bray_curtis", "hellinger", "chi_squared",
+              "jensen_shannon", "standardized_euclidean", "spearman")) {
+    M <- if (m %in% c("bray_curtis", "hellinger", "chi_squared",
+                      "jensen_shannon")) Ap else A
+    d <- fdist(M, method = m)
+    expect_equal(d, t(d), tolerance = tol, info = m)
+    expect_equal(diag(d), rep(0, nrow(M)), tolerance = tol, info = m)
+  }
+})


### PR DESCRIPTION
## Summary

Adds eight new pairwise distance backends to `fastDist`, each following the existing Rcpp/Armadillo + OpenMP pattern (symmetric/asymmetric branches, column-major access, same parallel thresholds). All are registered in `fdistregistry` and dispatched through `fdist()`.

| Method | Use case |
|---|---|
| `squared_euclidean` | clustering / k-means (Euclidean without the final `sqrt`) |
| `bray_curtis` | abundance / compositional data |
| `hellinger` | non-negative vectors / probability distributions |
| `chi_squared` | histograms, bag-of-words |
| `jensen_shannon` | divergence between distributions (rows normalized to sum 1; returns √JSD) |
| `haversine` | geospatial great-circle distance in km (lat/lon in degrees, requires 2 columns) |
| `standardized_euclidean` | features on different scales (per-feature variance from `A`) |
| `spearman` | rank correlation distance (`1 − ρ_s`) |

## Changes

- `src/fastDist.cpp` — eight new `[[Rcpp::export]]` backends plus a tie-aware `row_ranks` helper for Spearman; added `<vector>` include.
- `src/RcppExports.cpp`, `R/RcppExports.R` — generated wrappers and `CallEntries` updated to match.
- `R/registry.R` — new registry entries (method names: `squared_euclidean`, `bray_curtis`, `hellinger`, `chi_squared`, `jensen_shannon`, `haversine`, `standardized_euclidean`, `spearman`).
- `R/fdist.R`, `R/fastDist_cpp_docs.R`, `man/fdist.Rd` — roxygen docs and generated `.Rd` updated with formulas for each metric.
- `tests/testthat.R`, `tests/testthat/test-new-metrics.R` — new `testthat` suite validating every metric against base-R reference implementations, plus symmetry/zero-diagonal and input-validation checks.

## Notes / verification

- The `RcppExports.*` files were hand-edited to match `compileAttributes()` output, since the R toolchain isn't available in this environment. They should be regenerated with `Rcpp::compileAttributes()` if convenient, but the entries are consistent.
- The Spearman ranking logic and the Haversine formula were verified standalone in C++ (correct average ranks for ties; Madrid→Paris ≈ 1053 km).
- A package build / `R CMD check` against the test suite is recommended before merge, as it couldn't be run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01159UPnxt5W6pbDynZfXjPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01159UPnxt5W6pbDynZfXjPm)_