### PR TITLE
Add per-method extra parameters to fdistregistry entries

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -45,32 +45,32 @@
     .Call(`_fastDist_chisquared`, Ar, Br)
 }
 
-.jensenshannon <- function(Ar, Br) {
-    .Call(`_fastDist_jensenshannon`, Ar, Br)
+.jensenshannon <- function(Ar, Br, base) {
+    .Call(`_fastDist_jensenshannon`, Ar, Br, base)
 }
 
-.haversine <- function(Ar, Br) {
-    .Call(`_fastDist_haversine`, Ar, Br)
+.haversine <- function(Ar, Br, radius = 6371.0) {
+    .Call(`_fastDist_haversine`, Ar, Br, radius)
 }
 
-.standardized_euclidean <- function(Ar, Br) {
-    .Call(`_fastDist_standardized_euclidean`, Ar, Br)
+.standardized_euclidean <- function(Ar, Br, weights = NULL) {
+    .Call(`_fastDist_standardized_euclidean`, Ar, Br, weights)
 }
 
 .spearman <- function(Ar, Br) {
     .Call(`_fastDist_spearman`, Ar, Br)
 }
 
-.mahalanobis <- function(Ar) {
-    .Call(`_fastDist_mahalanobis`, Ar)
+.mahalanobis <- function(Ar, cov = NULL, regularize = 0.0) {
+    .Call(`_fastDist_mahalanobis`, Ar, cov, regularize)
 }
 
-.hamming <- function(Ar, Br) {
-    .Call(`_fastDist_hamming`, Ar, Br)
+.hamming <- function(Ar, Br, threshold = NA_real_) {
+    .Call(`_fastDist_hamming`, Ar, Br, threshold)
 }
 
-.jaccard <- function(Ar, Br) {
-    .Call(`_fastDist_jaccard`, Ar, Br)
+.jaccard <- function(Ar, Br, threshold = 0.0) {
+    .Call(`_fastDist_jaccard`, Ar, Br, threshold)
 }
 
 .gower <- function(Ar, Br) {

--- a/R/fdist.R
+++ b/R/fdist.R
@@ -14,38 +14,35 @@
 #'   `"bray_curtis"`, `"hellinger"`, `"chi_squared"`, `"jensen_shannon"`,
 #'   `"haversine"`, `"standardized_euclidean"`, `"spearman"`, `"mahalanobis"`,
 #'   `"hamming"`, `"jaccard"`, and `"gower"`.
-#' @param p Numeric scalar used only when `method = "minkowski"`. It is the
-#'   exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
-#'   definition). If `NULL` (the default), the value stored in
-#'   [fdistregistry] is used (`p = 2`).
-#' @param radius Numeric scalar used only when `method = "haversine"`. The
-#'   sphere radius the result is expressed in (e.g. `6371` for kilometres or
-#'   `3958.8` for miles). If `NULL` (the default), the value stored in
-#'   [fdistregistry] is used (`radius = 6371`, the mean Earth radius in km).
-#' @param base Used only when `method = "jensen_shannon"`. Either the
-#'   character shortcuts `"e"` / `"2"`, or a numeric logarithm base
-#'   (\eqn{b > 0}, \eqn{b \neq 1}). Controls the units of the underlying
-#'   divergence (nats for `"e"`, bits for `"2"`). If `NULL` (the default),
-#'   the value stored in [fdistregistry] is used (`base = exp(1)`, i.e.
-#'   natural log, matching the historical behaviour).
-#' @param threshold Numeric scalar used only when `method = "jaccard"` or
-#'   `method = "hamming"`. Values strictly greater than `threshold` are
-#'   treated as `1` (present) before comparing. If `NULL` (the default), the
-#'   value stored in [fdistregistry] is used: `0` for `"jaccard"`, and `NA`
-#'   for `"hamming"` (`NA` disables binarization, comparing raw values for
-#'   exact inequality as before).
-#' @param regularize Numeric scalar used only when `method = "mahalanobis"`.
-#'   Ridge added to the diagonal of the covariance matrix before inversion,
-#'   useful when it is singular or near-singular. If `NULL` (the default),
-#'   the value stored in [fdistregistry] is used (`regularize = 0`).
-#' @param weights Numeric vector used only when `method =
-#'   "standardized_euclidean"`. Per-feature scale used instead of the sample
-#'   variance of `A` (its length must equal `ncol(A)`). If `NULL` (the
-#'   default), the sample variance of `A` is used, as before.
-#' @param cov Numeric matrix used only when `method = "mahalanobis"`. A
-#'   precomputed covariance matrix (`ncol(A)` x `ncol(A)`) used instead of
-#'   the sample covariance of `A`. If `NULL` (the default), the sample
-#'   covariance of `A` is used, as before.
+#' @param ... Extra, method-specific parameters overriding the defaults
+#'   stored in [fdistregistry] (see `fdistregistry$get_entry(method)$params`
+#'   for the defaults of a given method). Recognized names are:
+#'   \describe{
+#'     \item{`p`}{(`method = "minkowski"`) exponent of the Minkowski metric
+#'     (\eqn{p \ge 1} in the standard metric definition). Defaults to `2`.}
+#'     \item{`radius`}{(`method = "haversine"`) sphere radius the result is
+#'     expressed in (e.g. `6371` for kilometres or `3958.8` for miles).
+#'     Defaults to `6371`.}
+#'     \item{`base`}{(`method = "jensen_shannon"`) either the character
+#'     shortcuts `"e"` / `"2"`, or a numeric logarithm base (\eqn{b > 0},
+#'     \eqn{b \neq 1}), controlling the units of the underlying divergence
+#'     (nats for `"e"`, bits for `"2"`). Defaults to `exp(1)` (natural log).}
+#'     \item{`threshold`}{(`method = "jaccard"` or `"hamming"`) values
+#'     strictly greater than `threshold` are treated as `1` (present)
+#'     before comparing. Defaults to `0` for `"jaccard"`; for `"hamming"`
+#'     it defaults to `NA`, which disables binarization and compares raw
+#'     values for exact inequality instead.}
+#'     \item{`regularize`}{(`method = "mahalanobis"`) ridge added to the
+#'     diagonal of the covariance matrix before inversion, useful when it
+#'     is singular or near-singular. Defaults to `0`.}
+#'     \item{`weights`}{(`method = "standardized_euclidean"`) numeric
+#'     vector with the per-feature scale used instead of the sample
+#'     variance of `A` (its length must equal `ncol(A)`). Defaults to
+#'     `NULL`, i.e. the sample variance of `A` is used.}
+#'     \item{`cov`}{(`method = "mahalanobis"`) numeric matrix (`ncol(A)` x
+#'     `ncol(A)`) with a precomputed covariance matrix used instead of the
+#'     sample covariance of `A`. Defaults to `NULL`.}
+#'   }
 #'
 #' @details
 #' Let \eqn{x_i = (x_{i1}, \ldots, x_{ik})} be row `i` from `A` and
@@ -221,51 +218,27 @@
 #'
 #' @seealso [fdistregistry] for the registry of available distance backends.
 #' @export
-fdist <- function(A, B = NULL, method, p = NULL, radius = NULL, base = NULL,
-                   threshold = NULL, regularize = NULL, weights = NULL,
-                   cov = NULL) {
+fdist <- function(A, B = NULL, method, ...) {
   if (!method %in% fdistregistry$get_entry_names()) {
     stop(paste(method, "not found in fdistregistry"))
   }
   A <- as.matrix(A)
   entry <- fdistregistry$get_entry(method)
+  params <- utils::modifyList(entry$params, list(...))
+
+  if (identical(method, "jensen_shannon") && !is.null(params$base)) {
+    params$base <- resolve_log_base(params$base)
+  }
 
   if (method == "mahalanobis") {
-    if (is.null(regularize)) {
-      regularize <- entry$regularize
-    }
-    result <- entry$fun(A, cov, regularize)
+    result <- do.call(entry$fun, c(list(A), params))
   } else {
     if (is.null(B)) {
       B <- A
     } else {
       B <- as.matrix(B)
     }
-    if (!is.na(entry$p)) {
-      if (is.null(p)) {
-        p <- entry$p
-      }
-      result <- entry$fun(A, B, p)
-    } else if (!is.na(entry$radius)) {
-      if (is.null(radius)) {
-        radius <- entry$radius
-      }
-      result <- entry$fun(A, B, radius)
-    } else if (!is.na(entry$base)) {
-      if (is.null(base)) {
-        base <- entry$base
-      }
-      result <- entry$fun(A, B, resolve_log_base(base))
-    } else if (method %in% c("jaccard", "hamming")) {
-      if (is.null(threshold)) {
-        threshold <- entry$threshold
-      }
-      result <- entry$fun(A, B, threshold)
-    } else if (method == "standardized_euclidean") {
-      result <- entry$fun(A, B, weights)
-    } else {
-      result <- entry$fun(A, B)
-    }
+    result <- do.call(entry$fun, c(list(A, B), params))
   }
 
   result

--- a/R/fdist.R
+++ b/R/fdist.R
@@ -18,6 +18,34 @@
 #'   exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
 #'   definition). If `NULL` (the default), the value stored in
 #'   [fdistregistry] is used (`p = 2`).
+#' @param radius Numeric scalar used only when `method = "haversine"`. The
+#'   sphere radius the result is expressed in (e.g. `6371` for kilometres or
+#'   `3958.8` for miles). If `NULL` (the default), the value stored in
+#'   [fdistregistry] is used (`radius = 6371`, the mean Earth radius in km).
+#' @param base Used only when `method = "jensen_shannon"`. Either the
+#'   character shortcuts `"e"` / `"2"`, or a numeric logarithm base
+#'   (\eqn{b > 0}, \eqn{b \neq 1}). Controls the units of the underlying
+#'   divergence (nats for `"e"`, bits for `"2"`). If `NULL` (the default),
+#'   the value stored in [fdistregistry] is used (`base = exp(1)`, i.e.
+#'   natural log, matching the historical behaviour).
+#' @param threshold Numeric scalar used only when `method = "jaccard"` or
+#'   `method = "hamming"`. Values strictly greater than `threshold` are
+#'   treated as `1` (present) before comparing. If `NULL` (the default), the
+#'   value stored in [fdistregistry] is used: `0` for `"jaccard"`, and `NA`
+#'   for `"hamming"` (`NA` disables binarization, comparing raw values for
+#'   exact inequality as before).
+#' @param regularize Numeric scalar used only when `method = "mahalanobis"`.
+#'   Ridge added to the diagonal of the covariance matrix before inversion,
+#'   useful when it is singular or near-singular. If `NULL` (the default),
+#'   the value stored in [fdistregistry] is used (`regularize = 0`).
+#' @param weights Numeric vector used only when `method =
+#'   "standardized_euclidean"`. Per-feature scale used instead of the sample
+#'   variance of `A` (its length must equal `ncol(A)`). If `NULL` (the
+#'   default), the sample variance of `A` is used, as before.
+#' @param cov Numeric matrix used only when `method = "mahalanobis"`. A
+#'   precomputed covariance matrix (`ncol(A)` x `ncol(A)`) used instead of
+#'   the sample covariance of `A`. If `NULL` (the default), the sample
+#'   covariance of `A` is used, as before.
 #'
 #' @details
 #' Let \eqn{x_i = (x_{i1}, \ldots, x_{ik})} be row `i` from `A` and
@@ -162,10 +190,19 @@
 #' # Minkowski distance of order p = 3
 #' fdist(A, B, method = "minkowski", p = 3)
 #'
+#' # Jensen-Shannon distance in bits (base 2) instead of nats
+#' fdist(A, method = "jensen_shannon", base = "2")
+#'
+#' # Mahalanobis distance with a regularized (ridge) covariance matrix
+#' fdist(A, method = "mahalanobis", regularize = 0.01)
+#'
 #' # binary data: Hamming and Jaccard distances
 #' X <- matrix(rbinom(5 * 8, 1, 0.5), nrow = 5, ncol = 8)
 #' fdist(X, method = "hamming")
 #' fdist(X, method = "jaccard")
+#'
+#' # continuous data binarized at a custom threshold before comparing
+#' fdist(A, method = "hamming", threshold = 0.5)
 #'
 #' # mixed-scale numeric data: Gower distance
 #' fdist(A, method = "gower")
@@ -176,34 +213,75 @@
 #'                 c(48.8566,  2.3522))  # Paris
 #' fdist(cities, method = "haversine")
 #'
+#' # Haversine distance in miles instead of the default kilometres
+#' fdist(cities, method = "haversine", radius = 3958.8)
+#'
 #' # all available methods
 #' fdistregistry$get_entry_names()
 #'
 #' @seealso [fdistregistry] for the registry of available distance backends.
 #' @export
-fdist <- function(A, B = NULL, method, p = NULL) {
+fdist <- function(A, B = NULL, method, p = NULL, radius = NULL, base = NULL,
+                   threshold = NULL, regularize = NULL, weights = NULL,
+                   cov = NULL) {
   if (!method %in% fdistregistry$get_entry_names()) {
     stop(paste(method, "not found in fdistregistry"))
   }
   A <- as.matrix(A)
   entry <- fdistregistry$get_entry(method)
+
   if (method == "mahalanobis") {
-    result <- entry$fun(A)
+    if (is.null(regularize)) {
+      regularize <- entry$regularize
+    }
+    result <- entry$fun(A, cov, regularize)
   } else {
     if (is.null(B)) {
       B <- A
     } else {
       B <- as.matrix(B)
     }
-    if (is.na(entry$p)) {
-      result <- entry$fun(A, B)
-    } else {
+    if (!is.na(entry$p)) {
       if (is.null(p)) {
         p <- entry$p
       }
       result <- entry$fun(A, B, p)
+    } else if (!is.na(entry$radius)) {
+      if (is.null(radius)) {
+        radius <- entry$radius
+      }
+      result <- entry$fun(A, B, radius)
+    } else if (!is.na(entry$base)) {
+      if (is.null(base)) {
+        base <- entry$base
+      }
+      result <- entry$fun(A, B, resolve_log_base(base))
+    } else if (method %in% c("jaccard", "hamming")) {
+      if (is.null(threshold)) {
+        threshold <- entry$threshold
+      }
+      result <- entry$fun(A, B, threshold)
+    } else if (method == "standardized_euclidean") {
+      result <- entry$fun(A, B, weights)
+    } else {
+      result <- entry$fun(A, B)
     }
   }
 
   result
+}
+
+# resolves the `base` argument of fdist() into a numeric logarithm base
+resolve_log_base <- function(base) {
+  if (is.character(base)) {
+    base <- switch(base,
+                    "e" = exp(1),
+                    "2" = 2,
+                    stop('base must be "e", "2", or a positive number other than 1'))
+  }
+  if (!is.numeric(base) || length(base) != 1L || is.na(base) ||
+      base <= 0 || base == 1) {
+    stop('base must be "e", "2", or a positive number other than 1')
+  }
+  base
 }

--- a/R/registry.R
+++ b/R/registry.R
@@ -4,9 +4,12 @@
 #' distance backends
 #' available to [fdist()]. Each entry stores the `method` name (the lookup
 #' key), the C++ backend function `fun`, a short human-readable
-#' `description`, and the default value of any extra parameter that method
-#' accepts (used unless overridden through the corresponding argument of
-#' [fdist()]):
+#' `description`, and `params`: a named list with the default value of every
+#' extra parameter that method accepts (used unless overridden through
+#' `...` in [fdist()]). Methods that take no extra parameter simply store
+#' an empty list.
+#'
+#' Currently registered extra parameters are:
 #'
 #' - `p`: exponent of the Minkowski distance (defaults to `2`).
 #' - `radius`: sphere radius used by the Haversine distance (defaults to
@@ -23,18 +26,18 @@
 #' - `cov`: precomputed covariance matrix used by the Mahalanobis distance
 #'   instead of the sample covariance of `A` (defaults to `NULL`).
 #'
-#' Methods that do not use a given parameter simply store its default
-#' (`NA` or `NULL`, depending on the field).
-#'
-#' The registry is mainly useful to discover which methods are available:
+#' The registry is mainly useful to discover which methods are available and
+#' which extra parameters they accept:
 #'
 #' - `fdistregistry$get_entry_names()` returns the method names accepted by
 #'   the `method` argument of [fdist()].
 #' - `fdistregistry$get_entry("euclidean")` returns the full entry of a
 #'   given method.
+#' - `fdistregistry$get_entry("haversine")$params` returns the extra
+#'   parameters (with their defaults) accepted by a given method.
 #'
-#' @format A `registry` object with fields `method`, `fun`, `description`,
-#'   `p`, `radius`, `base`, `threshold`, `regularize`, `weights` and `cov`.
+#' @format A `registry` object with fields `method`, `fun`, `description`
+#'   and `params`.
 #'
 #' @examples
 #' # methods accepted by fdist()
@@ -45,9 +48,9 @@
 #'        function(m) fdistregistry$get_entry(m)$description,
 #'        character(1))
 #'
-#' # default parameters of a specific method
-#' fdistregistry$get_entry("haversine")$radius
-#' fdistregistry$get_entry("mahalanobis")$regularize
+#' # extra parameters (and their defaults) accepted by a specific method
+#' fdistregistry$get_entry("haversine")$params
+#' fdistregistry$get_entry("mahalanobis")$params
 #'
 #' @seealso [fdist()]
 #' @export
@@ -60,20 +63,8 @@ fdistregistry$set_field("fun",
                         type = "function", is_key = FALSE)
 fdistregistry$set_field("description",
                         type = "character", is_key = FALSE)
-fdistregistry$set_field("p",
-                        type = "numeric", is_key = FALSE)
-fdistregistry$set_field("radius",
-                        type = "numeric", is_key = FALSE)
-fdistregistry$set_field("base",
-                        type = "numeric", is_key = FALSE)
-fdistregistry$set_field("threshold",
-                        type = "numeric", is_key = FALSE)
-fdistregistry$set_field("regularize",
-                        type = "numeric", is_key = FALSE)
-fdistregistry$set_field("weights",
-                        is_key = FALSE, default = NULL)
-fdistregistry$set_field("cov",
-                        is_key = FALSE, default = NULL)
+fdistregistry$set_field("params",
+                        is_key = FALSE, default = list())
 
 fdistregistry$set_entry(method = "euclidean",
                         fun    = .euclidean,
@@ -85,7 +76,7 @@ fdistregistry$set_entry(method = "manhattan",
 
 fdistregistry$set_entry(method = "minkowski",
                         fun    = .minkowski,
-                        p      = 2,
+                        params = list(p = 2),
                         description = "Minkowski distance")
 
 fdistregistry$set_entry(method = "correlation",
@@ -123,16 +114,17 @@ fdistregistry$set_entry(method = "chi_squared",
 
 fdistregistry$set_entry(method = "jensen_shannon",
                         fun    = .jensenshannon,
-                        base   = exp(1),
+                        params = list(base = exp(1)),
                         description = "Jensen-Shannon distance")
 
 fdistregistry$set_entry(method = "haversine",
                         fun    = .haversine,
-                        radius = 6371,
+                        params = list(radius = 6371),
                         description = "Haversine (great-circle) distance")
 
 fdistregistry$set_entry(method = "standardized_euclidean",
                         fun    = .standardized_euclidean,
+                        params = list(weights = NULL),
                         description = "standardized Euclidean distance")
 
 fdistregistry$set_entry(method = "spearman",
@@ -141,16 +133,17 @@ fdistregistry$set_entry(method = "spearman",
 
 fdistregistry$set_entry(method = "mahalanobis",
                         fun    = .mahalanobis,
-                        regularize = 0,
+                        params = list(cov = NULL, regularize = 0),
                         description = "Mahalanobis distance")
 
 fdistregistry$set_entry(method = "hamming",
                         fun    = .hamming,
+                        params = list(threshold = NA_real_),
                         description = "Hamming distance")
 
 fdistregistry$set_entry(method = "jaccard",
                         fun    = .jaccard,
-                        threshold = 0,
+                        params = list(threshold = 0),
                         description = "Jaccard distance")
 
 fdistregistry$set_entry(method = "gower",

--- a/R/registry.R
+++ b/R/registry.R
@@ -3,9 +3,28 @@
 #' A registry object (created with the \pkg{registry} package) holding the
 #' distance backends
 #' available to [fdist()]. Each entry stores the `method` name (the lookup
-#' key), the C++ backend function `fun`, an optional numeric parameter `p`
-#' (only used by the Minkowski distance, where it defaults to `2`) and a
-#' short human-readable `description`.
+#' key), the C++ backend function `fun`, a short human-readable
+#' `description`, and the default value of any extra parameter that method
+#' accepts (used unless overridden through the corresponding argument of
+#' [fdist()]):
+#'
+#' - `p`: exponent of the Minkowski distance (defaults to `2`).
+#' - `radius`: sphere radius used by the Haversine distance (defaults to
+#'   `6371`, the mean Earth radius in km).
+#' - `base`: logarithm base used by the Jensen-Shannon distance (defaults to
+#'   `exp(1)`, i.e. natural log).
+#' - `threshold`: value above which a feature is considered "present" when
+#'   binarizing data for the Jaccard (defaults to `0`) and Hamming (defaults
+#'   to `NA`, meaning raw values are compared instead of binarized) distances.
+#' - `regularize`: ridge added to the diagonal of the covariance matrix used
+#'   by the Mahalanobis distance before inversion (defaults to `0`).
+#' - `weights`: per-feature scale used by the standardized Euclidean
+#'   distance instead of the sample variance of `A` (defaults to `NULL`).
+#' - `cov`: precomputed covariance matrix used by the Mahalanobis distance
+#'   instead of the sample covariance of `A` (defaults to `NULL`).
+#'
+#' Methods that do not use a given parameter simply store its default
+#' (`NA` or `NULL`, depending on the field).
 #'
 #' The registry is mainly useful to discover which methods are available:
 #'
@@ -14,8 +33,8 @@
 #' - `fdistregistry$get_entry("euclidean")` returns the full entry of a
 #'   given method.
 #'
-#' @format A `registry` object with fields `method`, `fun`, `p` and
-#'   `description`.
+#' @format A `registry` object with fields `method`, `fun`, `description`,
+#'   `p`, `radius`, `base`, `threshold`, `regularize`, `weights` and `cov`.
 #'
 #' @examples
 #' # methods accepted by fdist()
@@ -26,6 +45,10 @@
 #'        function(m) fdistregistry$get_entry(m)$description,
 #'        character(1))
 #'
+#' # default parameters of a specific method
+#' fdistregistry$get_entry("haversine")$radius
+#' fdistregistry$get_entry("mahalanobis")$regularize
+#'
 #' @seealso [fdist()]
 #' @export
 fdistregistry <- registry::registry()
@@ -35,10 +58,22 @@ fdistregistry$set_field("method",
                         index_FUN = registry::match_partial_ignorecase)
 fdistregistry$set_field("fun",
                         type = "function", is_key = FALSE)
-fdistregistry$set_field("p",
-                        type = "numeric", is_key = FALSE)
 fdistregistry$set_field("description",
                         type = "character", is_key = FALSE)
+fdistregistry$set_field("p",
+                        type = "numeric", is_key = FALSE)
+fdistregistry$set_field("radius",
+                        type = "numeric", is_key = FALSE)
+fdistregistry$set_field("base",
+                        type = "numeric", is_key = FALSE)
+fdistregistry$set_field("threshold",
+                        type = "numeric", is_key = FALSE)
+fdistregistry$set_field("regularize",
+                        type = "numeric", is_key = FALSE)
+fdistregistry$set_field("weights",
+                        is_key = FALSE, default = NULL)
+fdistregistry$set_field("cov",
+                        is_key = FALSE, default = NULL)
 
 fdistregistry$set_entry(method = "euclidean",
                         fun    = .euclidean,
@@ -88,10 +123,12 @@ fdistregistry$set_entry(method = "chi_squared",
 
 fdistregistry$set_entry(method = "jensen_shannon",
                         fun    = .jensenshannon,
+                        base   = exp(1),
                         description = "Jensen-Shannon distance")
 
 fdistregistry$set_entry(method = "haversine",
                         fun    = .haversine,
+                        radius = 6371,
                         description = "Haversine (great-circle) distance")
 
 fdistregistry$set_entry(method = "standardized_euclidean",
@@ -104,6 +141,7 @@ fdistregistry$set_entry(method = "spearman",
 
 fdistregistry$set_entry(method = "mahalanobis",
                         fun    = .mahalanobis,
+                        regularize = 0,
                         description = "Mahalanobis distance")
 
 fdistregistry$set_entry(method = "hamming",
@@ -112,6 +150,7 @@ fdistregistry$set_entry(method = "hamming",
 
 fdistregistry$set_entry(method = "jaccard",
                         fun    = .jaccard,
+                        threshold = 0,
                         description = "Jaccard distance")
 
 fdistregistry$set_entry(method = "gower",

--- a/man/fdist.Rd
+++ b/man/fdist.Rd
@@ -4,18 +4,7 @@
 \alias{fdist}
 \title{Fast Pairwise Distance Computation Between Observations}
 \usage{
-fdist(
-  A,
-  B = NULL,
-  method,
-  p = NULL,
-  radius = NULL,
-  base = NULL,
-  threshold = NULL,
-  regularize = NULL,
-  weights = NULL,
-  cov = NULL
-)
+fdist(A, B = NULL, method, ...)
 }
 \arguments{
 \item{A}{A matrix (or object coercible to a matrix) containing source
@@ -32,43 +21,35 @@ values are \code{"euclidean"}, \code{"manhattan"}, \code{"minkowski"}, \code{"co
 \code{"haversine"}, \code{"standardized_euclidean"}, \code{"spearman"}, \code{"mahalanobis"},
 \code{"hamming"}, \code{"jaccard"}, and \code{"gower"}.}
 
-\item{p}{Numeric scalar used only when \code{method = "minkowski"}. It is the
-exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
-definition). If \code{NULL} (the default), the value stored in
-\link{fdistregistry} is used (\code{p = 2}).}
-
-\item{radius}{Numeric scalar used only when \code{method = "haversine"}. The
-sphere radius the result is expressed in (e.g. \code{6371} for kilometres or
-\code{3958.8} for miles). If \code{NULL} (the default), the value stored in
-\link{fdistregistry} is used (\code{radius = 6371}, the mean Earth radius in km).}
-
-\item{base}{Used only when \code{method = "jensen_shannon"}. Either the
-character shortcuts \code{"e"} / \code{"2"}, or a numeric logarithm base
-(\eqn{b > 0}, \eqn{b \neq 1}). Controls the units of the underlying
-divergence (nats for \code{"e"}, bits for \code{"2"}). If \code{NULL} (the default),
-the value stored in \link{fdistregistry} is used (\code{base = exp(1)}, i.e.
-natural log, matching the historical behaviour).}
-
-\item{threshold}{Numeric scalar used only when \code{method = "jaccard"} or
-\code{method = "hamming"}. Values strictly greater than \code{threshold} are
-treated as \code{1} (present) before comparing. If \code{NULL} (the default), the
-value stored in \link{fdistregistry} is used: \code{0} for \code{"jaccard"}, and \code{NA}
-for \code{"hamming"} (\code{NA} disables binarization, comparing raw values for
-exact inequality as before).}
-
-\item{regularize}{Numeric scalar used only when \code{method = "mahalanobis"}.
-Ridge added to the diagonal of the covariance matrix before inversion,
-useful when it is singular or near-singular. If \code{NULL} (the default),
-the value stored in \link{fdistregistry} is used (\code{regularize = 0}).}
-
-\item{weights}{Numeric vector used only when \code{method = "standardized_euclidean"}. Per-feature scale used instead of the sample
-variance of \code{A} (its length must equal \code{ncol(A)}). If \code{NULL} (the
-default), the sample variance of \code{A} is used, as before.}
-
-\item{cov}{Numeric matrix used only when \code{method = "mahalanobis"}. A
-precomputed covariance matrix (\code{ncol(A)} x \code{ncol(A)}) used instead of
-the sample covariance of \code{A}. If \code{NULL} (the default), the sample
-covariance of \code{A} is used, as before.}
+\item{...}{Extra, method-specific parameters overriding the defaults
+stored in \link{fdistregistry} (see \code{fdistregistry$get_entry(method)$params}
+for the defaults of a given method). Recognized names are:
+\describe{
+\item{\code{p}}{(\code{method = "minkowski"}) exponent of the Minkowski metric
+(\eqn{p \ge 1} in the standard metric definition). Defaults to \code{2}.}
+\item{\code{radius}}{(\code{method = "haversine"}) sphere radius the result is
+expressed in (e.g. \code{6371} for kilometres or \code{3958.8} for miles).
+Defaults to \code{6371}.}
+\item{\code{base}}{(\code{method = "jensen_shannon"}) either the character
+shortcuts \code{"e"} / \code{"2"}, or a numeric logarithm base (\eqn{b > 0},
+\eqn{b \neq 1}), controlling the units of the underlying divergence
+(nats for \code{"e"}, bits for \code{"2"}). Defaults to \code{exp(1)} (natural log).}
+\item{\code{threshold}}{(\code{method = "jaccard"} or \code{"hamming"}) values
+strictly greater than \code{threshold} are treated as \code{1} (present)
+before comparing. Defaults to \code{0} for \code{"jaccard"}; for \code{"hamming"}
+it defaults to \code{NA}, which disables binarization and compares raw
+values for exact inequality instead.}
+\item{\code{regularize}}{(\code{method = "mahalanobis"}) ridge added to the
+diagonal of the covariance matrix before inversion, useful when it
+is singular or near-singular. Defaults to \code{0}.}
+\item{\code{weights}}{(\code{method = "standardized_euclidean"}) numeric
+vector with the per-feature scale used instead of the sample
+variance of \code{A} (its length must equal \code{ncol(A)}). Defaults to
+\code{NULL}, i.e. the sample variance of \code{A} is used.}
+\item{\code{cov}}{(\code{method = "mahalanobis"}) numeric matrix (\code{ncol(A)} x
+\code{ncol(A)}) with a precomputed covariance matrix used instead of the
+sample covariance of \code{A}. Defaults to \code{NULL}.}
+}}
 }
 \value{
 A numeric matrix where entry \verb{[i, j]} is the distance between row

--- a/man/fdist.Rd
+++ b/man/fdist.Rd
@@ -4,7 +4,18 @@
 \alias{fdist}
 \title{Fast Pairwise Distance Computation Between Observations}
 \usage{
-fdist(A, B = NULL, method, p = NULL)
+fdist(
+  A,
+  B = NULL,
+  method,
+  p = NULL,
+  radius = NULL,
+  base = NULL,
+  threshold = NULL,
+  regularize = NULL,
+  weights = NULL,
+  cov = NULL
+)
 }
 \arguments{
 \item{A}{A matrix (or object coercible to a matrix) containing source
@@ -25,6 +36,39 @@ values are \code{"euclidean"}, \code{"manhattan"}, \code{"minkowski"}, \code{"co
 exponent of the Minkowski metric (\eqn{p \ge 1} in the standard metric
 definition). If \code{NULL} (the default), the value stored in
 \link{fdistregistry} is used (\code{p = 2}).}
+
+\item{radius}{Numeric scalar used only when \code{method = "haversine"}. The
+sphere radius the result is expressed in (e.g. \code{6371} for kilometres or
+\code{3958.8} for miles). If \code{NULL} (the default), the value stored in
+\link{fdistregistry} is used (\code{radius = 6371}, the mean Earth radius in km).}
+
+\item{base}{Used only when \code{method = "jensen_shannon"}. Either the
+character shortcuts \code{"e"} / \code{"2"}, or a numeric logarithm base
+(\eqn{b > 0}, \eqn{b \neq 1}). Controls the units of the underlying
+divergence (nats for \code{"e"}, bits for \code{"2"}). If \code{NULL} (the default),
+the value stored in \link{fdistregistry} is used (\code{base = exp(1)}, i.e.
+natural log, matching the historical behaviour).}
+
+\item{threshold}{Numeric scalar used only when \code{method = "jaccard"} or
+\code{method = "hamming"}. Values strictly greater than \code{threshold} are
+treated as \code{1} (present) before comparing. If \code{NULL} (the default), the
+value stored in \link{fdistregistry} is used: \code{0} for \code{"jaccard"}, and \code{NA}
+for \code{"hamming"} (\code{NA} disables binarization, comparing raw values for
+exact inequality as before).}
+
+\item{regularize}{Numeric scalar used only when \code{method = "mahalanobis"}.
+Ridge added to the diagonal of the covariance matrix before inversion,
+useful when it is singular or near-singular. If \code{NULL} (the default),
+the value stored in \link{fdistregistry} is used (\code{regularize = 0}).}
+
+\item{weights}{Numeric vector used only when \code{method = "standardized_euclidean"}. Per-feature scale used instead of the sample
+variance of \code{A} (its length must equal \code{ncol(A)}). If \code{NULL} (the
+default), the sample variance of \code{A} is used, as before.}
+
+\item{cov}{Numeric matrix used only when \code{method = "mahalanobis"}. A
+precomputed covariance matrix (\code{ncol(A)} x \code{ncol(A)}) used instead of
+the sample covariance of \code{A}. If \code{NULL} (the default), the sample
+covariance of \code{A} is used, as before.}
 }
 \value{
 A numeric matrix where entry \verb{[i, j]} is the distance between row
@@ -174,10 +218,19 @@ fdist(A, method = "manhattan")
 # Minkowski distance of order p = 3
 fdist(A, B, method = "minkowski", p = 3)
 
+# Jensen-Shannon distance in bits (base 2) instead of nats
+fdist(A, method = "jensen_shannon", base = "2")
+
+# Mahalanobis distance with a regularized (ridge) covariance matrix
+fdist(A, method = "mahalanobis", regularize = 0.01)
+
 # binary data: Hamming and Jaccard distances
 X <- matrix(rbinom(5 * 8, 1, 0.5), nrow = 5, ncol = 8)
 fdist(X, method = "hamming")
 fdist(X, method = "jaccard")
+
+# continuous data binarized at a custom threshold before comparing
+fdist(A, method = "hamming", threshold = 0.5)
 
 # mixed-scale numeric data: Gower distance
 fdist(A, method = "gower")
@@ -187,6 +240,9 @@ cities <- rbind(c(40.4168, -3.7038),  # Madrid
                 c(41.3851,  2.1734),  # Barcelona
                 c(48.8566,  2.3522))  # Paris
 fdist(cities, method = "haversine")
+
+# Haversine distance in miles instead of the default kilometres
+fdist(cities, method = "haversine", radius = 3958.8)
 
 # all available methods
 fdistregistry$get_entry_names()

--- a/man/fdistregistry.Rd
+++ b/man/fdistregistry.Rd
@@ -5,8 +5,8 @@
 \alias{fdistregistry}
 \title{Registry of Distance Backends}
 \format{
-A \code{registry} object with fields \code{method}, \code{fun}, \code{description},
-\code{p}, \code{radius}, \code{base}, \code{threshold}, \code{regularize}, \code{weights} and \code{cov}.
+A \code{registry} object with fields \code{method}, \code{fun}, \code{description}
+and \code{params}.
 }
 \usage{
 fdistregistry
@@ -16,11 +16,13 @@ A registry object (created with the \pkg{registry} package) holding the
 distance backends
 available to \code{\link[=fdist]{fdist()}}. Each entry stores the \code{method} name (the lookup
 key), the C++ backend function \code{fun}, a short human-readable
-\code{description}, and the default value of any extra parameter that method
-accepts (used unless overridden through the corresponding argument of
-\code{\link[=fdist]{fdist()}}):
+\code{description}, and \code{params}: a named list with the default value of every
+extra parameter that method accepts (used unless overridden through
+\code{...} in \code{\link[=fdist]{fdist()}}). Methods that take no extra parameter simply store
+an empty list.
 }
 \details{
+Currently registered extra parameters are:
 \itemize{
 \item \code{p}: exponent of the Minkowski distance (defaults to \code{2}).
 \item \code{radius}: sphere radius used by the Haversine distance (defaults to
@@ -38,15 +40,15 @@ distance instead of the sample variance of \code{A} (defaults to \code{NULL}).
 instead of the sample covariance of \code{A} (defaults to \code{NULL}).
 }
 
-Methods that do not use a given parameter simply store its default
-(\code{NA} or \code{NULL}, depending on the field).
-
-The registry is mainly useful to discover which methods are available:
+The registry is mainly useful to discover which methods are available and
+which extra parameters they accept:
 \itemize{
 \item \code{fdistregistry$get_entry_names()} returns the method names accepted by
 the \code{method} argument of \code{\link[=fdist]{fdist()}}.
 \item \code{fdistregistry$get_entry("euclidean")} returns the full entry of a
 given method.
+\item \code{fdistregistry$get_entry("haversine")$params} returns the extra
+parameters (with their defaults) accepted by a given method.
 }
 }
 \examples{
@@ -58,9 +60,9 @@ vapply(fdistregistry$get_entry_names(),
        function(m) fdistregistry$get_entry(m)$description,
        character(1))
 
-# default parameters of a specific method
-fdistregistry$get_entry("haversine")$radius
-fdistregistry$get_entry("mahalanobis")$regularize
+# extra parameters (and their defaults) accepted by a specific method
+fdistregistry$get_entry("haversine")$params
+fdistregistry$get_entry("mahalanobis")$params
 
 }
 \seealso{

--- a/man/fdistregistry.Rd
+++ b/man/fdistregistry.Rd
@@ -5,8 +5,8 @@
 \alias{fdistregistry}
 \title{Registry of Distance Backends}
 \format{
-A \code{registry} object with fields \code{method}, \code{fun}, \code{p} and
-\code{description}.
+A \code{registry} object with fields \code{method}, \code{fun}, \code{description},
+\code{p}, \code{radius}, \code{base}, \code{threshold}, \code{regularize}, \code{weights} and \code{cov}.
 }
 \usage{
 fdistregistry
@@ -15,11 +15,32 @@ fdistregistry
 A registry object (created with the \pkg{registry} package) holding the
 distance backends
 available to \code{\link[=fdist]{fdist()}}. Each entry stores the \code{method} name (the lookup
-key), the C++ backend function \code{fun}, an optional numeric parameter \code{p}
-(only used by the Minkowski distance, where it defaults to \code{2}) and a
-short human-readable \code{description}.
+key), the C++ backend function \code{fun}, a short human-readable
+\code{description}, and the default value of any extra parameter that method
+accepts (used unless overridden through the corresponding argument of
+\code{\link[=fdist]{fdist()}}):
 }
 \details{
+\itemize{
+\item \code{p}: exponent of the Minkowski distance (defaults to \code{2}).
+\item \code{radius}: sphere radius used by the Haversine distance (defaults to
+\code{6371}, the mean Earth radius in km).
+\item \code{base}: logarithm base used by the Jensen-Shannon distance (defaults to
+\code{exp(1)}, i.e. natural log).
+\item \code{threshold}: value above which a feature is considered "present" when
+binarizing data for the Jaccard (defaults to \code{0}) and Hamming (defaults
+to \code{NA}, meaning raw values are compared instead of binarized) distances.
+\item \code{regularize}: ridge added to the diagonal of the covariance matrix used
+by the Mahalanobis distance before inversion (defaults to \code{0}).
+\item \code{weights}: per-feature scale used by the standardized Euclidean
+distance instead of the sample variance of \code{A} (defaults to \code{NULL}).
+\item \code{cov}: precomputed covariance matrix used by the Mahalanobis distance
+instead of the sample covariance of \code{A} (defaults to \code{NULL}).
+}
+
+Methods that do not use a given parameter simply store its default
+(\code{NA} or \code{NULL}, depending on the field).
+
 The registry is mainly useful to discover which methods are available:
 \itemize{
 \item \code{fdistregistry$get_entry_names()} returns the method names accepted by
@@ -36,6 +57,10 @@ fdistregistry$get_entry_names()
 vapply(fdistregistry$get_entry_names(),
        function(m) fdistregistry$get_entry(m)$description,
        character(1))
+
+# default parameters of a specific method
+fdistregistry$get_entry("haversine")$radius
+fdistregistry$get_entry("mahalanobis")$regularize
 
 }
 \seealso{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -145,38 +145,41 @@ BEGIN_RCPP
 END_RCPP
 }
 // jensenshannon
-NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br);
-RcppExport SEXP _fastDist_jensenshannon(SEXP ArSEXP, SEXP BrSEXP) {
+NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br, double base);
+RcppExport SEXP _fastDist_jensenshannon(SEXP ArSEXP, SEXP BrSEXP, SEXP baseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
-    rcpp_result_gen = Rcpp::wrap(jensenshannon(Ar, Br));
+    Rcpp::traits::input_parameter< double >::type base(baseSEXP);
+    rcpp_result_gen = Rcpp::wrap(jensenshannon(Ar, Br, base));
     return rcpp_result_gen;
 END_RCPP
 }
 // haversine
-NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br);
-RcppExport SEXP _fastDist_haversine(SEXP ArSEXP, SEXP BrSEXP) {
+NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br, double radius);
+RcppExport SEXP _fastDist_haversine(SEXP ArSEXP, SEXP BrSEXP, SEXP radiusSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
-    rcpp_result_gen = Rcpp::wrap(haversine(Ar, Br));
+    Rcpp::traits::input_parameter< double >::type radius(radiusSEXP);
+    rcpp_result_gen = Rcpp::wrap(haversine(Ar, Br, radius));
     return rcpp_result_gen;
 END_RCPP
 }
 // standardized_euclidean
-NumericMatrix standardized_euclidean(NumericMatrix Ar, NumericMatrix Br);
-RcppExport SEXP _fastDist_standardized_euclidean(SEXP ArSEXP, SEXP BrSEXP) {
+NumericMatrix standardized_euclidean(NumericMatrix Ar, NumericMatrix Br, Rcpp::Nullable<NumericVector> weights);
+RcppExport SEXP _fastDist_standardized_euclidean(SEXP ArSEXP, SEXP BrSEXP, SEXP weightsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
-    rcpp_result_gen = Rcpp::wrap(standardized_euclidean(Ar, Br));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<NumericVector> >::type weights(weightsSEXP);
+    rcpp_result_gen = Rcpp::wrap(standardized_euclidean(Ar, Br, weights));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -193,37 +196,41 @@ BEGIN_RCPP
 END_RCPP
 }
 // mahalanobis
-NumericMatrix mahalanobis(NumericMatrix Ar);
-RcppExport SEXP _fastDist_mahalanobis(SEXP ArSEXP) {
+NumericMatrix mahalanobis(NumericMatrix Ar, Rcpp::Nullable<NumericMatrix> cov, double regularize);
+RcppExport SEXP _fastDist_mahalanobis(SEXP ArSEXP, SEXP covSEXP, SEXP regularizeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
-    rcpp_result_gen = Rcpp::wrap(mahalanobis(Ar));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<NumericMatrix> >::type cov(covSEXP);
+    Rcpp::traits::input_parameter< double >::type regularize(regularizeSEXP);
+    rcpp_result_gen = Rcpp::wrap(mahalanobis(Ar, cov, regularize));
     return rcpp_result_gen;
 END_RCPP
 }
 // hamming
-NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br);
-RcppExport SEXP _fastDist_hamming(SEXP ArSEXP, SEXP BrSEXP) {
+NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br, double threshold);
+RcppExport SEXP _fastDist_hamming(SEXP ArSEXP, SEXP BrSEXP, SEXP thresholdSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
-    rcpp_result_gen = Rcpp::wrap(hamming(Ar, Br));
+    Rcpp::traits::input_parameter< double >::type threshold(thresholdSEXP);
+    rcpp_result_gen = Rcpp::wrap(hamming(Ar, Br, threshold));
     return rcpp_result_gen;
 END_RCPP
 }
 // jaccard
-NumericMatrix jaccard(NumericMatrix Ar, NumericMatrix Br);
-RcppExport SEXP _fastDist_jaccard(SEXP ArSEXP, SEXP BrSEXP) {
+NumericMatrix jaccard(NumericMatrix Ar, NumericMatrix Br, double threshold);
+RcppExport SEXP _fastDist_jaccard(SEXP ArSEXP, SEXP BrSEXP, SEXP thresholdSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type Ar(ArSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type Br(BrSEXP);
-    rcpp_result_gen = Rcpp::wrap(jaccard(Ar, Br));
+    Rcpp::traits::input_parameter< double >::type threshold(thresholdSEXP);
+    rcpp_result_gen = Rcpp::wrap(jaccard(Ar, Br, threshold));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -252,13 +259,13 @@ static const R_CallMethodDef CallEntries[] = {
     {"_fastDist_braycurtis", (DL_FUNC) &_fastDist_braycurtis, 2},
     {"_fastDist_hellinger", (DL_FUNC) &_fastDist_hellinger, 2},
     {"_fastDist_chisquared", (DL_FUNC) &_fastDist_chisquared, 2},
-    {"_fastDist_jensenshannon", (DL_FUNC) &_fastDist_jensenshannon, 2},
-    {"_fastDist_haversine", (DL_FUNC) &_fastDist_haversine, 2},
-    {"_fastDist_standardized_euclidean", (DL_FUNC) &_fastDist_standardized_euclidean, 2},
+    {"_fastDist_jensenshannon", (DL_FUNC) &_fastDist_jensenshannon, 3},
+    {"_fastDist_haversine", (DL_FUNC) &_fastDist_haversine, 3},
+    {"_fastDist_standardized_euclidean", (DL_FUNC) &_fastDist_standardized_euclidean, 3},
     {"_fastDist_spearman", (DL_FUNC) &_fastDist_spearman, 2},
-    {"_fastDist_mahalanobis", (DL_FUNC) &_fastDist_mahalanobis, 1},
-    {"_fastDist_hamming", (DL_FUNC) &_fastDist_hamming, 2},
-    {"_fastDist_jaccard", (DL_FUNC) &_fastDist_jaccard, 2},
+    {"_fastDist_mahalanobis", (DL_FUNC) &_fastDist_mahalanobis, 3},
+    {"_fastDist_hamming", (DL_FUNC) &_fastDist_hamming, 3},
+    {"_fastDist_jaccard", (DL_FUNC) &_fastDist_jaccard, 3},
     {"_fastDist_gower", (DL_FUNC) &_fastDist_gower, 2},
     {NULL, NULL, 0}
 };

--- a/src/fastDist.cpp
+++ b/src/fastDist.cpp
@@ -635,8 +635,9 @@ NumericMatrix chisquared(NumericMatrix Ar, NumericMatrix Br) {
 
 
 // jensen-shannon distance
+// base is the logarithm base (M_E for natural log, 2 for bits, ...)
 // [[Rcpp::export(.jensenshannon)]]
-NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br) {
+NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br, double base = M_E) {
   int m = Ar.nrow(),
     n = Br.nrow(),
     k = Ar.ncol();
@@ -644,6 +645,7 @@ NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br) {
   arma::mat B = arma::mat(Br.begin(), n, k, false);
   arma::mat res = arma::mat(m, n, arma::fill::zeros);
   const bool symmetric = same_input(Ar, Br);
+  const double log_base = std::log(base);
 
   // normalise each row to a probability distribution (sum to 1)
   arma::colvec sumA = arma::sum(A, 1);
@@ -668,7 +670,7 @@ NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br) {
           if (q > 0.0) acc += 0.5 * q * std::log(q / mid);
         }
         if (acc < 0.0) acc = 0.0;
-        const double dist = std::sqrt(acc);
+        const double dist = std::sqrt(acc / log_base);
         res(i, j) = dist;
         if (i != j) res(j, i) = dist;
       }
@@ -686,7 +688,7 @@ NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br) {
           if (q > 0.0) acc += 0.5 * q * std::log(q / mid);
         }
         if (acc < 0.0) acc = 0.0;
-        res(i, j) = std::sqrt(acc);
+        res(i, j) = std::sqrt(acc / log_base);
       }
     }
   }
@@ -695,9 +697,9 @@ NumericMatrix jensenshannon(NumericMatrix Ar, NumericMatrix Br) {
 }
 
 
-// haversine (great-circle) distance, in kilometres
+// haversine (great-circle) distance
 // [[Rcpp::export(.haversine)]]
-NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br) {
+NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br, double radius = 6371.0) {
   int m = Ar.nrow(),
     n = Br.nrow(),
     k = Ar.ncol();
@@ -711,7 +713,7 @@ NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br) {
   const double* Ap = A.memptr();
   const double* Bp = B.memptr();
   const double deg2rad = M_PI / 180.0;
-  const double R = 6371.0; // mean Earth radius in km
+  const double R = radius; // sphere radius, in the same unit as the result
 
   if (symmetric) {
 #pragma omp parallel for schedule(static) if(m * m > 10000)
@@ -756,9 +758,11 @@ NumericMatrix haversine(NumericMatrix Ar, NumericMatrix Br) {
 
 
 // standardized euclidean distance
-// (each feature scaled by its sample variance, estimated from A)
+// each feature is scaled by 1 / weights[col]; if weights is not supplied,
+// the sample variance of A is used (n-1 denominator)
 // [[Rcpp::export(.standardized_euclidean)]]
-NumericMatrix standardized_euclidean(NumericMatrix Ar, NumericMatrix Br) {
+NumericMatrix standardized_euclidean(NumericMatrix Ar, NumericMatrix Br,
+                                      Rcpp::Nullable<NumericVector> weights = R_NilValue) {
   int m = Ar.nrow(),
     n = Br.nrow(),
     k = Ar.ncol();
@@ -769,11 +773,21 @@ NumericMatrix standardized_euclidean(NumericMatrix Ar, NumericMatrix Br) {
   const double* Ap = A.memptr();
   const double* Bp = B.memptr();
 
-  // per-feature sample variance from A (n-1 denominator)
-  arma::rowvec var = arma::var(A, 0, 0);
   arma::vec inv_var(k);
-  for (int col = 0; col < k; col++) {
-    inv_var[col] = var[col] > 0.0 ? 1.0 / var[col] : 0.0;
+  if (weights.isNotNull()) {
+    NumericVector w(weights);
+    if (w.size() != k) {
+      stop("weights must have length equal to ncol(A)");
+    }
+    for (int col = 0; col < k; col++) {
+      inv_var[col] = w[col] > 0.0 ? 1.0 / w[col] : 0.0;
+    }
+  } else {
+    // per-feature sample variance from A (n-1 denominator)
+    arma::rowvec var = arma::var(A, 0, 0);
+    for (int col = 0; col < k; col++) {
+      inv_var[col] = var[col] > 0.0 ? 1.0 / var[col] : 0.0;
+    }
   }
 
   if (symmetric) {
@@ -920,12 +934,32 @@ NumericMatrix spearman(NumericMatrix Ar, NumericMatrix Br) {
 
 
 // mahalanobis distance
+// cov: precomputed covariance matrix (k x k); if NULL, estimated from A
+// regularize: ridge added to the diagonal of the covariance matrix before
+// inversion, useful when it is singular or near-singular
 // [[Rcpp::export(.mahalanobis)]]
-NumericMatrix mahalanobis(NumericMatrix Ar) {
+NumericMatrix mahalanobis(NumericMatrix Ar,
+                           Rcpp::Nullable<NumericMatrix> cov = R_NilValue,
+                           double regularize = 0.0) {
   int m = Ar.nrow(),
     k = Ar.ncol();
   arma::mat A = arma::mat(Ar.begin(), m, k, false);
-  arma::mat S = arma::inv_sympd(arma::cov(A));
+
+  arma::mat covMat;
+  if (cov.isNotNull()) {
+    NumericMatrix covR(cov);
+    if (covR.nrow() != k || covR.ncol() != k) {
+      stop("cov must be a square matrix with as many rows/columns as A has columns");
+    }
+    covMat = arma::mat(covR.begin(), k, k);
+  } else {
+    covMat = arma::cov(A);
+  }
+  if (regularize > 0.0) {
+    covMat += regularize * arma::eye<arma::mat>(k, k);
+  }
+
+  arma::mat S = arma::inv_sympd(covMat);
   arma::mat AS = A * S;
   arma::vec q = arma::sum(AS % A, 1);
   arma::mat res = arma::mat(m, m, arma::fill::zeros);
@@ -953,8 +987,10 @@ NumericMatrix mahalanobis(NumericMatrix Ar) {
 
 
 // hamming distance (binary/categorical)
+// threshold: if not NA, A and B are binarized as (value > threshold) before
+// comparing, instead of comparing raw values for exact inequality
 // [[Rcpp::export(.hamming)]]
-NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br) {
+NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br, double threshold = NA_REAL) {
   int m = Ar.nrow(),
     n = Br.nrow(),
     k = Ar.ncol();
@@ -964,6 +1000,7 @@ NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br) {
   const bool symmetric = same_input(Ar, Br);
   const double* Ap = A.memptr();
   const double* Bp = B.memptr();
+  const bool binarize = !ISNA(threshold);
 
   if (symmetric) {
 #pragma omp parallel for schedule(static) if(m * m > 10000)
@@ -971,7 +1008,10 @@ NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br) {
       for (int j = i; j < m; j++) {
         int dist = 0;
         for (int col = 0; col < k; col++) {
-          if (Ap[col * m + i] != Bp[col * n + j]) {
+          const double a = Ap[col * m + i];
+          const double b = Bp[col * n + j];
+          const bool differ = binarize ? ((a > threshold) != (b > threshold)) : (a != b);
+          if (differ) {
             dist++;
           }
         }
@@ -985,7 +1025,10 @@ NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br) {
       for (int j = 0; j < n; j++) {
         int dist = 0;
         for (int col = 0; col < k; col++) {
-          if (Ap[col * m + i] != Bp[col * n + j]) {
+          const double a = Ap[col * m + i];
+          const double b = Bp[col * n + j];
+          const bool differ = binarize ? ((a > threshold) != (b > threshold)) : (a != b);
+          if (differ) {
             dist++;
           }
         }
@@ -999,8 +1042,10 @@ NumericMatrix hamming(NumericMatrix Ar, NumericMatrix Br) {
 
 
 // jaccard distance (binary/set-based)
+// threshold: values > threshold are treated as 1 (default 0, i.e. any
+// positive value counts as present)
 // [[Rcpp::export(.jaccard)]]
-NumericMatrix jaccard(NumericMatrix Ar, NumericMatrix Br) {
+NumericMatrix jaccard(NumericMatrix Ar, NumericMatrix Br, double threshold = 0.0) {
   int m = Ar.nrow(),
     n = Br.nrow(),
     k = Ar.ncol();
@@ -1017,8 +1062,8 @@ NumericMatrix jaccard(NumericMatrix Ar, NumericMatrix Br) {
       for (int j = i; j < m; j++) {
         int intersection = 0, union_size = 0;
         for (int col = 0; col < k; col++) {
-          const bool ai = Ap[col * m + i] != 0.0;
-          const bool bi = Bp[col * n + j] != 0.0;
+          const bool ai = Ap[col * m + i] > threshold;
+          const bool bi = Bp[col * n + j] > threshold;
           if (ai || bi) union_size++;
           if (ai && bi) intersection++;
         }
@@ -1033,8 +1078,8 @@ NumericMatrix jaccard(NumericMatrix Ar, NumericMatrix Br) {
       for (int j = 0; j < n; j++) {
         int intersection = 0, union_size = 0;
         for (int col = 0; col < k; col++) {
-          const bool ai = Ap[col * m + i] != 0.0;
-          const bool bi = Bp[col * n + j] != 0.0;
+          const bool ai = Ap[col * m + i] > threshold;
+          const bool bi = Bp[col * n + j] > threshold;
           if (ai || bi) union_size++;
           if (ai && bi) intersection++;
         }

--- a/vignettes/fastDist.Rmd
+++ b/vignettes/fastDist.Rmd
@@ -95,10 +95,12 @@ fdist(A, B, method = "manhattan")
 
 `standardized_euclidean` scales each feature by its sample variance
 (estimated from `A`), which makes the metric insensitive to the units in
-which each column is measured:
+which each column is measured. A custom per-feature scale can be supplied
+through `weights` instead:
 
 ```{r}
 fdist(A, B, method = "standardized_euclidean")
+fdist(A, B, method = "standardized_euclidean", weights = c(1, 1, 1))
 ```
 
 ### Shape-based metrics: correlation, cosine and Spearman
@@ -130,6 +132,14 @@ fdist(P, Q, method = "jensen_shannon")
 fdist(P, Q, method = "bray_curtis")
 ```
 
+`jensen_shannon` uses natural log by default; pass `base = "2"` (or any
+positive number other than 1) to express the divergence in a different base,
+e.g. bits instead of nats:
+
+```{r}
+fdist(P, Q, method = "jensen_shannon", base = "2")
+```
+
 ### Binary and categorical data: Hamming and Jaccard
 
 `hamming` counts the number of positions in which two rows differ, which
@@ -140,11 +150,22 @@ X <- matrix(rbinom(6 * 8, 1, 0.5), nrow = 6)
 fdist(X, method = "hamming")
 ```
 
-`jaccard` treats each row as a set (non-zero entries are members) and
-returns one minus the ratio of the intersection to the union:
+`jaccard` treats each row as a set (values greater than `threshold`, which
+defaults to `0`, are members) and returns one minus the ratio of the
+intersection to the union:
 
 ```{r}
 fdist(X, method = "jaccard")
+```
+
+For continuous data, `threshold` can be used to binarize both `hamming` and
+`jaccard` inputs before comparing (for `hamming`, the default is to compare
+raw values instead, as above):
+
+```{r}
+Y <- matrix(runif(6 * 8), nrow = 6)
+fdist(Y, method = "hamming", threshold = 0.5)
+fdist(Y, method = "jaccard", threshold = 0.5)
 ```
 
 ### Mixed-scale data: Gower
@@ -178,6 +199,13 @@ cities <- matrix(
 fdist(cities, method = "haversine")
 ```
 
+The result is expressed in kilometres by default (`radius = 6371`, the mean
+Earth radius); pass a different `radius` to use another unit, e.g. miles:
+
+```{r}
+fdist(cities, method = "haversine", radius = 3958.8)
+```
+
 ### Covariance-aware data: Mahalanobis
 
 `method = "mahalanobis"` always works within the rows of `A` (any `B` is
@@ -185,6 +213,15 @@ ignored) and uses the sample covariance matrix estimated from `A`:
 
 ```{r}
 fdist(A, method = "mahalanobis")
+```
+
+A precomputed covariance matrix can be supplied through `cov` instead of
+estimating it from `A`, and `regularize` adds a ridge to its diagonal before
+inversion, which helps when the covariance matrix is singular or
+near-singular (e.g. more features than observations):
+
+```{r}
+fdist(A, method = "mahalanobis", regularize = 0.1)
 ```
 
 ## Performance


### PR DESCRIPTION
## Summary

Extends `fdistregistry` entries with per-method default parameters, replacing magic numbers hardcoded in the C++ backends with registry-driven defaults that `fdist()` can look up and callers can override:

- **`mahalanobis`**: new `cov` (precomputed covariance matrix) and `regularize` (ridge added to the covariance diagonal before inversion, useful when it's singular/near-singular) params.
- **`haversine`**: new `radius` param (defaults to `6371`, the mean Earth radius in km) so the same backend can be reused for other units (e.g. miles).
- **`standardized_euclidean`**: new `weights` param (per-feature scale) to use instead of always computing the sample variance from `A`.
- **`jensen_shannon`**: new `base` param (`"e"`, `"2"`, or any numeric log base) controlling the units of the underlying divergence (nats vs bits), matching scipy's convention.
- **`jaccard` / `hamming`**: new `threshold` param to binarize continuous inputs (`value > threshold`) before comparing, instead of only treating exact non-zero/inequality as "different".

All new registry fields default to values that reproduce the exact previous behavior when not supplied, so existing calls to `fdist()` are unaffected.

## Test plan

- [x] `R CMD INSTALL .` — package compiles and installs cleanly
- [x] `testthat::test_dir("tests/testthat")` — all 40 existing tests pass
- [x] `R CMD check` — no new WARNINGs/NOTEs introduced (pre-existing vignette-build and `registry` import notes unrelated to this change)
- [x] Manual verification in R: `radius`, `base`, `threshold`, `regularize`, `weights`, `cov` all produce the expected numeric results (e.g. `cov = diag(k)` on `mahalanobis` reproduces `euclidean`; `weights = rep(1, k)` on `standardized_euclidean` reproduces `euclidean`; `base = "2"` on `jensen_shannon` scales the divergence by `1/log(2)`) and invalid inputs raise clear errors
- [x] `vignettes/fastDist.Rmd` updated with usage examples for each new parameter and knits without errors

https://claude.ai/code/session_01REgZWFAJrbFjm8nJgQ3pke


---
_Generated by [Claude Code](https://claude.ai/code/session_01REgZWFAJrbFjm8nJgQ3pke)_